### PR TITLE
Refactor CSP code so it can be open sourced

### DIFF
--- a/include/driver/sdr_driver.h
+++ b/include/driver/sdr_driver.h
@@ -9,7 +9,7 @@
 extern "C" {
 #endif
 
-#define SDR_GNURADIO 1
+// #define SDR_GNURADIO 1
 
 typedef enum {
     SDR_UHF_1200_BAUD = 0,
@@ -52,23 +52,34 @@ typedef void (*sdr_rx_callback_t) (void *udata, uint8_t *data, size_t len, void*
 
 struct sdr_interface_data;
 
-typedef struct {
-    uint16_t mtu;
+typedef struct sdr_uhf_conf {
     sdr_uhf_baud_rate_t uhf_baudrate;
     int uart_baudrate;
     char *device_file;
-    sdr_rx_callback_t rx_callback;
-    void *rx_callback_data;
 } sdr_uhf_conf_t;
 
+typedef struct sdr_sband_conf {
+    uint32_t bytes_until_sync;
+    uint32_t filling;
+    uint32_t last_time;
+} sdr_sband_conf_t;
+
+typedef struct sdr_conf {
+    sdr_rx_callback_t rx_callback;
+    void *rx_callback_data;
+    struct sdr_uhf_conf uhf_conf;
+    struct sdr_sband_conf sband_conf;
+} sdr_conf_t;
+
 typedef struct sdr_interface_data {
+    uint16_t mtu;
     uintptr_t fd;
     /** Low Level Transmit Function */
     sdr_tx_t tx_func;
     /** Low level Receive function */
     os_queue_handle_t rx_queue;
     void *mac_data;
-    sdr_uhf_conf_t *sdr_conf;
+    sdr_conf_t *sdr_conf;
     /** Low level buffer state */
     uint16_t rx_mpdu_index;
     uint8_t *rx_mpdu;
@@ -78,11 +89,13 @@ typedef struct sdr_interface_data {
 #define SDR_IF_SBAND_NAME "S-BAND"
 #define SDR_IF_LOOPBACK_NAME "LOOPBACK"
 
-sdr_interface_data_t *sdr_uhf_interface_init(const sdr_uhf_conf_t *conf, const char *ifname);
+sdr_interface_data_t* sdr_interface_init(const sdr_conf_t *conf, const char *ifname);
+
 int sdr_uart_driver_init(sdr_interface_data_t *ifdata);
-int sdr_gnuradio_driver_init(sdr_interface_data_t *ifdata);
+int sdr_sband_driver_init(sdr_interface_data_t *ifdata);
 
 int sdr_uhf_tx(sdr_interface_data_t *ifdata, uint8_t *data, uint16_t len);
+int sdr_sband_tx(sdr_interface_data_t *ifdata, uint8_t *data, uint16_t len);
 
 void sdr_rx_isr(void *cb_data, uint8_t *buf, size_t len, void *pxTaskWoken);
 

--- a/include/utilities/osal.h
+++ b/include/utilities/osal.h
@@ -31,6 +31,7 @@ void* os_malloc(size_t size);
 void os_free(void *ptr);
 
 void os_sleep_ms(uint32_t time_ms);
+uint32_t os_get_ms(void);
 
 typedef void* os_queue_handle_t;
 

--- a/lib/driver/sdr_init.c
+++ b/lib/driver/sdr_init.c
@@ -6,35 +6,35 @@
 
 void sdr_loopback_open(sdr_interface_data_t *ifdata);
 
-static int sdr_uhf_driver_init(sdr_interface_data_t *ifdata, const char *ifname) {
-    sdr_uhf_conf_t *sdr_conf = ifdata->sdr_conf;
+static int sdr_driver_init(sdr_interface_data_t *ifdata, const char *ifname) {
     int rc;
 
     if (strcmp(ifname, SDR_IF_LOOPBACK_NAME) == 0) {
         sdr_loopback_open(ifdata);
     }
-    else {
-#ifdef SDR_GNURADIO
-        if ((rc = sdr_gnuradio_driver_init(ifdata))) {
-#else
+    else if (strcmp(ifname, SDR_IF_UHF_NAME) == 0) {
         if ((rc = sdr_uart_driver_init(ifdata))) {
-#endif
+            return rc;
+        }
+    }
+    else if (strcmp(ifname, SDR_IF_SBAND_NAME) == 0) {
+        if ((rc = sdr_sband_driver_init(ifdata))) {
             return rc;
         }
     }
 
-    ifdata->rx_queue = os_queue_create(2, sdr_conf->mtu);
+    ifdata->rx_queue = os_queue_create(2, ifdata->mtu);
     ifdata->mac_data = fec_create(RF_MODE_3, NO_FEC);
     ifdata->rx_mpdu_index = 0;
-    ifdata->rx_mpdu = os_malloc(sdr_conf->mtu);
+    ifdata->rx_mpdu = os_malloc(ifdata->mtu);
 
     rc = os_task_create(sdr_rx_task, "sdr_rx", OS_RX_TASK_STACK_SIZE, (void *)ifdata, 0, NULL);
 
     return rc;
 }
 
-sdr_interface_data_t *sdr_uhf_interface_init(const sdr_uhf_conf_t *conf, const char *ifname) {
-    sdr_uhf_conf_t *sdr_conf = os_malloc(sizeof(sdr_uhf_conf_t));
+sdr_interface_data_t *sdr_interface_init(const sdr_conf_t *conf, const char *ifname) {
+    sdr_conf_t *sdr_conf = os_malloc(sizeof(sdr_conf_t));
     sdr_interface_data_t *ifdata = os_malloc(sizeof(sdr_interface_data_t));
     if (!sdr_conf || !ifdata) {
         os_free(sdr_conf);
@@ -42,11 +42,13 @@ sdr_interface_data_t *sdr_uhf_interface_init(const sdr_uhf_conf_t *conf, const c
         return NULL;
     }
 
-    memcpy(sdr_conf, conf, sizeof(sdr_uhf_conf_t));
-    memset(ifdata, 0, sizeof(sdr_interface_data_t));
+    memcpy(sdr_conf, conf, sizeof(*sdr_conf));
+    memset(ifdata, 0, sizeof(*ifdata));
+
+    ifdata->mtu = SDR_UHF_MAX_MTU;
     ifdata->sdr_conf = sdr_conf;
 
-    int rc = sdr_uhf_driver_init(ifdata, ifname);
+    int rc = sdr_driver_init(ifdata, ifname);
     if (rc) {
         os_free(sdr_conf);
         os_free(ifdata);

--- a/lib/utilities/osal.c
+++ b/lib/utilities/osal.c
@@ -115,4 +115,8 @@ int os_task_create(os_task_func_t routine, const char * const task_name, unsigne
 	return (ret == 1)? 0 : ret;
 }
 
+uint32_t os_get_ms() {
+	return (uint32_t)(xTaskGetTickCount() * (1000/configTICK_RATE_HZ));
+}
+
 #endif // OS_FREERTOS


### PR DESCRIPTION
Most of the CSP independent code for the UHF FEC/SDR/MPDU driver has been moved out of libcsp and into ex2_sdr
