### PR TITLE
s-band tx support

### DIFF
--- a/include/driver/sdr_driver.h
+++ b/include/driver/sdr_driver.h
@@ -4,6 +4,7 @@
 #include <stddef.h>
 #include <stdint.h>
 #include "osal.h"
+#include "sdr_sband.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -58,13 +59,6 @@ typedef struct sdr_uhf_conf {
     char *device_file;
 } sdr_uhf_conf_t;
 
-typedef struct sdr_sband_conf {
-    uint32_t bytes_until_sync;
-    uint16_t state;
-    uint16_t fifo_count;
-    uint32_t last_time;
-} sdr_sband_conf_t;
-
 typedef struct sdr_conf {
     sdr_rx_callback_t rx_callback;
     void *rx_callback_data;
@@ -93,17 +87,12 @@ typedef struct sdr_interface_data {
 sdr_interface_data_t* sdr_interface_init(const sdr_conf_t *conf, const char *ifname);
 
 int sdr_uart_driver_init(sdr_interface_data_t *ifdata);
-int sdr_sband_driver_init(sdr_interface_data_t *ifdata);
 
 int sdr_uhf_tx(sdr_interface_data_t *ifdata, uint8_t *data, uint16_t len);
-int sdr_sband_tx(sdr_interface_data_t *ifdata, uint8_t *data, uint16_t len);
 
 void sdr_rx_isr(void *cb_data, uint8_t *buf, size_t len, void *pxTaskWoken);
 
 os_task_return_t sdr_rx_task(void *param);
-
-void sdr_sband_tx_start(sdr_interface_data_t *ifdata);
-void sdr_sband_tx_stop(sdr_interface_data_t *ifdata);
 
 #ifdef __cplusplus
 }

--- a/include/driver/sdr_driver.h
+++ b/include/driver/sdr_driver.h
@@ -60,7 +60,8 @@ typedef struct sdr_uhf_conf {
 
 typedef struct sdr_sband_conf {
     uint32_t bytes_until_sync;
-    uint32_t filling;
+    uint16_t state;
+    uint16_t fifo_count;
     uint32_t last_time;
 } sdr_sband_conf_t;
 
@@ -100,6 +101,9 @@ int sdr_sband_tx(sdr_interface_data_t *ifdata, uint8_t *data, uint16_t len);
 void sdr_rx_isr(void *cb_data, uint8_t *buf, size_t len, void *pxTaskWoken);
 
 os_task_return_t sdr_rx_task(void *param);
+
+void sdr_sband_tx_start(sdr_interface_data_t *ifdata);
+void sdr_sband_tx_stop(sdr_interface_data_t *ifdata);
 
 #ifdef __cplusplus
 }

--- a/include/driver/sdr_sband.h
+++ b/include/driver/sdr_sband.h
@@ -1,0 +1,46 @@
+#ifndef SDR_SBAND_H_
+#define SDR_SBAND_H_
+
+#ifdef OS_POSIX
+// These don't exist (and aren't needed) on Linux
+static bool sband_enter_conf_mode() { return true; }
+static bool sband_enter_sync_mode() { return true; }
+static bool sband_enter_data_mode() { return true; }
+
+static void sband_sync() {}
+
+static int sband_transmit_ready(void) { return 1; }
+
+static bool sband_buffer_count(uint16_t *cnt) { return true; }
+
+#else
+#include <sband.h>
+#endif
+
+/* Send an S-Band Sync word every sync interval bytes */
+#define SBAND_SYNC_INTERVAL 8*1024
+
+#define SBAND_FIFO_DEPTH 20*1024
+
+/* The manual says the radio drains in about 41msec, or about 512bytes/msec */
+#define SBAND_DRAIN_RATE 512
+
+typedef struct sdr_sband_conf {
+    uint32_t bytes_until_sync;
+    uint16_t state;
+    uint16_t fifo_count;
+    uint16_t fill_cnt[16];
+    uint16_t drain_cnt[16];
+} sdr_sband_conf_t;
+
+struct sdr_interface_data;
+
+int sdr_sband_driver_init(struct sdr_interface_data *ifdata);
+
+int sdr_sband_tx(struct sdr_interface_data *ifdata, uint8_t *data, uint16_t len);
+
+void sdr_sband_tx_start(struct sdr_interface_data *ifdata);
+void sdr_sband_tx_stop(struct sdr_interface_data *ifdata);
+
+#endif /* SDR_SBAND_H_ */
+

--- a/include/driver/sdr_sband.h
+++ b/include/driver/sdr_sband.h
@@ -1,21 +1,25 @@
 #ifndef SDR_SBAND_H_
 #define SDR_SBAND_H_
 
+#include <osal.h>
+
 #ifdef OS_POSIX
+#include <stdbool.h>
+
 // These don't exist (and aren't needed) on Linux
-static bool sband_enter_conf_mode() { return true; }
-static bool sband_enter_sync_mode() { return true; }
-static bool sband_enter_data_mode() { return true; }
+bool sband_enter_conf_mode(void);
+bool sband_enter_sync_mode(void);
+bool sband_enter_data_mode(void);
 
-static void sband_sync() {}
+void sband_sync(void);
 
-static int sband_transmit_ready(void) { return 1; }
+int sband_transmit_ready(void);
 
-static bool sband_buffer_count(uint16_t *cnt) { return true; }
+bool sband_buffer_count(uint16_t *cnt);
 
 #else
 #include <sband.h>
-#endif
+#endif // OS_POSIX
 
 /* Send an S-Band Sync word every sync interval bytes */
 #define SBAND_SYNC_INTERVAL 8*1024

--- a/include/utilities/osal.h
+++ b/include/utilities/osal.h
@@ -1,6 +1,8 @@
 #ifndef OSAL_H_
 #define OSAL_H_
 
+#include <stdint.h>
+
 #ifdef __cplusplus
 extern "C" {
 #endif

--- a/include/utilities/osal.h
+++ b/include/utilities/osal.h
@@ -31,6 +31,7 @@ void* os_malloc(size_t size);
 void os_free(void *ptr);
 
 void os_sleep_ms(uint32_t time_ms);
+uint32_t os_get_ms(void);
 
 typedef void* os_queue_handle_t;
 

--- a/include/utilities/osal.h
+++ b/include/utilities/osal.h
@@ -49,6 +49,8 @@ typedef os_task_return_t (*os_task_func_t)(void* parameter);
 #if defined(OS_POSIX)
 #define OS_MAX_TIMEOUT (UINT32_MAX)
 #define OS_RX_TASK_STACK_SIZE 1024
+
+#define ex2_log printf
 #elif defined(OS_FREERTOS)
 #include "FreeRTOS.h"
 #define OS_MAX_TIMEOUT portMAX_DELAY

--- a/lib/driver/sdr_driver.c
+++ b/lib/driver/sdr_driver.c
@@ -57,7 +57,6 @@ void sdr_sband_tx_stop(sdr_interface_data_t *ifdata) {
     if (sband_buffer_count(&fifo_level)) {
         // The manual says the radio transmits at 512 bytes/msec
         delay = (fifo_level + SBAND_DRAIN_RATE/2)/(SBAND_DRAIN_RATE);
-        printf("%s: fifo %d", __FUNCTION__, fifo_level);
     }
     os_sleep_ms(delay);
     sband_enter_conf_mode();

--- a/lib/driver/sdr_driver.c
+++ b/lib/driver/sdr_driver.c
@@ -1,4 +1,5 @@
 #include <string.h>
+#include <sband.h>
 #include "sdr_driver.h"
 #include "fec.h"
 #include "osal.h"
@@ -33,14 +34,53 @@ int sdr_uhf_tx(sdr_interface_data_t *ifdata, uint8_t *data, uint16_t len) {
     return 0;
 }
 
+#define SBAND_IDLE 0
+#define SBAND_FIRST_FILL 1
+#define SBAND_FILL 2
+#define SBAND_DRAIN 3
+
+void sdr_sband_tx_start(sdr_interface_data_t *ifdata) {
+    sdr_sband_conf_t *sband_conf = &(ifdata->sdr_conf->sband_conf);
+
+    sband_conf->state = SBAND_FIRST_FILL;
+    sband_enter_sync_mode();
+}
+
+void sdr_sband_tx_stop(sdr_interface_data_t *ifdata) {
+    sdr_sband_conf_t *sband_conf = &ifdata->sdr_conf->sband_conf;
+
+    sband_conf->state = SBAND_IDLE;
+    sband_enter_conf_mode();
+}
+
 int sdr_sband_tx(sdr_interface_data_t *ifdata, uint8_t *data, uint16_t len) {
+    sdr_sband_conf_t *sband_conf = &ifdata->sdr_conf->sband_conf;
+
     if (fec_data_to_mpdu(ifdata->mac_data, data, len)) {
         uint8_t *buf;
         size_t mtu = (size_t)fec_get_next_mpdu(ifdata->mac_data, (void **)&buf);
         while (mtu != 0) {
+            if (sband_conf->bytes_until_sync == 0) {
+                sband_sync();
+                sband_conf->bytes_until_sync = SBAND_SYNC_INTERVAL;
+            }
+
             (ifdata->tx_func)(ifdata->fd, buf, mtu);
+
+            sband_conf->bytes_until_sync -= mtu;
+            sband_conf->fifo_count += mtu;
+
+            if (sband_conf->fifo_count >= (SBAND_FIFO_DEPTH - 1024)) {
+                if (sband_conf->state == SBAND_FIRST_FILL)
+                    sband_enter_data_mode();
+
+                /* Manual says a full drain takes about 41ms */
+                os_sleep_ms(30);
+
+                sband_conf->state = SBAND_FILL;
+                sband_buffer_count(&(sband_conf->fifo_count));
+            }
             mtu = fec_get_next_mpdu(ifdata->mac_data, (void **)&buf);
-            os_sleep_ms(100);
         }
     }
 

--- a/lib/utilities/osal.c
+++ b/lib/utilities/osal.c
@@ -115,4 +115,8 @@ int os_task_create(os_task_func_t routine, const char * const task_name, unsigne
 	return (ret == 1)? 0 : ret;
 }
 
+uint32_t os_get_ms() {
+	return (uint32_t)(xTaskGetTickCount() * (1000/configTICK_RATE_HZ));
+}
+
 #endif // OS_FREERTOS

--- a/lib/utilities/sband.c
+++ b/lib/utilities/sband.c
@@ -1,0 +1,18 @@
+#include <stdint.h>
+#include <stdbool.h>
+#include <sdr_driver.h>
+
+#ifdef OS_POSIX
+
+// These don't exist (and aren't needed) on Linux
+bool sband_enter_conf_mode() { return true; }
+bool sband_enter_sync_mode() { return true; }
+bool sband_enter_data_mode() { return true; }
+
+void sband_sync() {}
+
+int sband_transmit_ready(void) { return 1; }
+
+bool sband_buffer_count(uint16_t *cnt) { return true; }
+
+#endif


### PR DESCRIPTION
These changes include the expected API for working with s-band on the OBC. I also confirmed that the changes compile on the ground station. The feature is not working yet, but you can use the example in sdr_test() to write code for s-band.