### PR TITLE
s-band driver changes 

### DIFF
--- a/include/driver/sdr_sband.h
+++ b/include/driver/sdr_sband.h
@@ -25,18 +25,19 @@ bool sband_buffer_count(uint16_t *cnt);
 #define SBAND_SYNC_INTERVAL 8*1024
 
 #define SBAND_FIFO_DEPTH 20*1024
+#define SBAND_FIFO_READY_COUNT 2561
 
-/* The manual says the radio drains in about 41msec, or about 512bytes/msec */
+/* The manual says the radio drains in about 41msec, or about 512bytes/msec
+ * at full data rate. Half data rate drains in 82msec, etc.
+ */
 #define SBAND_DRAIN_RATE 512
 
 typedef struct sdr_sband_conf {
     uint32_t bytes_until_sync;
     uint16_t state;
     uint16_t fifo_count;
-    uint8_t  fillx;
-    uint8_t  drainx;
-    uint16_t fill_cnt[16];
-    uint16_t drain_cnt[16];
+    uint16_t too_slow;   // Incremented when we are filling too slowly
+    uint16_t too_fast;   // Incremented when we are draining too slowly 
 } sdr_sband_conf_t;
 
 struct sdr_interface_data;

--- a/include/driver/sdr_sband.h
+++ b/include/driver/sdr_sband.h
@@ -33,6 +33,8 @@ typedef struct sdr_sband_conf {
     uint32_t bytes_until_sync;
     uint16_t state;
     uint16_t fifo_count;
+    uint8_t  fillx;
+    uint8_t  drainx;
     uint16_t fill_cnt[16];
     uint16_t drain_cnt[16];
 } sdr_sband_conf_t;

--- a/lib/driver/sdr_driver.c
+++ b/lib/driver/sdr_driver.c
@@ -91,7 +91,7 @@ int sdr_sband_tx(sdr_interface_data_t *ifdata, uint8_t *data, uint16_t len) {
             if (sband_conf->fifo_count >= (SBAND_FIFO_DEPTH - 1024)) {
                 if (sband_conf->state == SBAND_FIRST_FILL)
                     sband_enter_data_mode();
-
+#if 0
                 sband_buffer_count(&(sband_conf->fill_cnt[sband_conf->fillx]));
                 if (++(sband_conf->fillx) >= 16) sband_conf->fillx = 0;
 
@@ -102,6 +102,14 @@ int sdr_sband_tx(sdr_interface_data_t *ifdata, uint8_t *data, uint16_t len) {
                 sband_buffer_count(&(sband_conf->fifo_count));
                 sband_conf->drain_cnt[sband_conf->drainx] = sband_conf->fifo_count;
                 if (++(sband_conf->drainx) >= 16) sband_conf->drainx = 0;
+#else
+                while (!sband_transmit_ready()) {
+                    os_sleep_ms(30);
+                }
+
+                sband_conf->state = SBAND_FILL;
+                sband_conf->fifo_count = 2048;
+#endif
             }
             mtu = fec_get_next_mpdu(ifdata->mac_data, (void **)&buf);
         }


### PR DESCRIPTION
Added a drain that uses the GPIO instead of the I2C register reads. Testing is still on-going, but I wanted to be able to clone master to get the most up-to-date versions that we are aware of.
