### PR TITLE
Ksk/mpdu error corner cases

### DIFF
--- a/include/error_control/golay.h
+++ b/include/error_control/golay.h
@@ -28,24 +28,49 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  */
+
+/*!
+ * @file golay.h
+ * @author StevenKnudsen
+ * @date Aug 7, 2022
+ *
+ * @details Changes to original code and documentation.
+ *
+ * @copyright See original file information above.
+ *
+ * @license GPL, see above
+ */
+
 #ifndef EX2_SDR__GOLAY_H__
 #define EX2_SDR__GOLAY_H__
 
 #include <stdint.h>
 
-/* encodes a 12-bit word to a 24-bit codeword
+/*!
+ * @brief Encodes a 12-bit word to a 24-bit codeword
+ * @param[in] message The 12-bit message word
+ * @return The 24-bit encoded message word aka codeword
  */
-uint32_t golay_encode(uint16_t w);
+uint32_t golay_encode(uint16_t message);
 
-/* return a mask showing the bits which are in error in a received
- * 24-bit codeword, or -1 if 4 errors were detected.
+/*!
+ * @brief Return a mask showing the bits which are in error in a received 24-bit
+ * codeword, or -1 if 4, 6, 8, 10, or 12 errors were detected. If the number of
+ * errors is odd, a mask is returned, but it likely not valid so don't rely on it.
+ * @param[in] codeword The Golay-encoded 12 message bits
+ * @return A mask showing the bits that are in error in the received 24-bit
+ * codeword
  */
 int32_t golay_errors(uint32_t codeword);
 
-/* decode a received codeword. Up to 3 errors are corrected for; 4
+/*!
+ * @brief Decode the input codeword. Up to 3 errors are corrected for; 4
    errors are detected as uncorrectable (return -1); 5 or more errors
-   cause an incorrect correction.
-*/
-int16_t golay_decode(uint32_t w);
+   cause an incorrect correction, that is, the result cannot be relied on and
+   some other check should be done.
+ * @param[in] codeword The Golay-encoded message
+ * @return
+ */
+int16_t golay_decode(uint32_t codeword);
 
 #endif // EX2_SDR__GOLAY_H__

--- a/include/mac_layer/mac.hpp
+++ b/include/mac_layer/mac.hpp
@@ -112,11 +112,6 @@ namespace ex2
         // All the necessary UHF packets have been received and an application
         // packet was formed and must be removed.
         PACKET_READY = 0x0000,
-        // Not all the necessary UHF packets have been received, but there are
-        // no more expected. An application packet was formed and must be
-        // removed. Then the last UHF packet must be resubmitted.
-        PACKET_READY_RESUBMIT_PREVIOUS_PACKET = 0x0001,
-        // @todo this is not used at this point, eliminate?
         // Not all the necessary UHF packets have been received, waiting for
         // the next one.
         READY_FOR_NEXT_UHF_PACKET = 0x0002
@@ -213,6 +208,8 @@ namespace ex2
       void m_updateErrorCorrection(
         ErrorCorrection::ErrorCorrectionScheme errorCorrectionScheme);
 
+      void m_processFirstMPDU(MPDU &firstMPDU);
+
       void m_decodePacket();
 
       // member vars that define the MAC operation
@@ -222,10 +219,6 @@ namespace ex2
 
       RF_Mode::RF_ModeNumber m_rfModeNumber;
 
-      // Mutexs to ensure that in progress packet processing is not corrupted
-      // by an inadvertant change in FEC parameters
-//      std::mutex m_ecSchemeMutex;
-
       // buffers needed to fragment a packet prior to transmission
       std::vector<uint8_t> m_codewordBuffer;
       std::vector<uint8_t> m_transparentModePayloads;
@@ -233,8 +226,8 @@ namespace ex2
       // member vars to track received packet fragments
       bool m_firstFragmentReceived;
       uint16_t m_currentPacketLength;
-      uint16_t m_expectedMPDUs;
-      uint16_t m_mpduCount;
+      uint16_t m_numExpectedMpduCodewordFragments;
+      uint16_t m_mpduCodewordFragmentCount;
 
       float m_SNREstimate;
 

--- a/include/mac_layer/pdu/mpdu.hpp
+++ b/include/mac_layer/pdu/mpdu.hpp
@@ -136,9 +136,12 @@ namespace ex2
        * valid, an MPDU will be made. If there is not enough data past the
        * MPDUHeader in @p rawMPDU, bytes will be added to the codeword
        *
+       * @param[in] currentErrorCorrection The current ErrorCorrection scheme in
+       * use by the MAC.
        * @param[in] rawMPDU The received transparent mode Data Field 2 as a byte vector
        */
       MPDU (
+        const ErrorCorrection &currentErrorCorrection,
         std::vector<uint8_t> &rawMPDU);
 
       ~MPDU ();

--- a/include/mac_layer/pdu/mpduHeader.hpp
+++ b/include/mac_layer/pdu/mpduHeader.hpp
@@ -1,11 +1,11 @@
 /*!
- * @file frameheader.h
+ * @file MPDUHeader.h
  * @author Steven Knudsen
  * @date April 30, 2021
  *
- * @details
- *
- * @todo change the user packet fragment index to be a CRC8 field
+ * @details Represents the MPDU header, which contains information about the
+ * radio RF Mode, Error Correction scheme, which codeword fragment and packet
+ * fragment this is, and the original payload length.
  *
  * @copyright AlbertaSat 2021
  *
@@ -24,8 +24,6 @@
 #include "pdu.hpp"
 #include "rfMode.hpp"
 
-#define TRANSPARENT_MODE_DATA_FIELD_2_MAX_LEN 128 // bytes
-
 namespace ex2 {
   namespace sdr {
 
@@ -37,7 +35,6 @@ namespace ex2 {
 
     class MPDUHeader {
     public:
-
 
       /*!
        * @brief Constructor
@@ -62,11 +59,14 @@ namespace ex2 {
        * @details Reconstitute a header object from raw (received, we assume)
        * bytes. Check the data for correctness and throw an exepction if bad.
        *
+       * @param[in] currentErrorCorrection The current ErrorCorrection scheme in
+       * use by the MAC.
        * @param[in] rawHeader The first @p k_MACHeaderLength / 8 bytes of this
        * vector are assumed to contain the MACHeader information.
        * @throws MPDUHeaderException
        */
-      MPDUHeader (std::vector<uint8_t> &rawHeader);
+      MPDUHeader (const ErrorCorrection &currentErrorCorrection,
+        std::vector<uint8_t> &rawHeader);
 
       /*!
        * @brief Copy Constructor

--- a/lib/mac_layer/mac.cpp
+++ b/lib/mac_layer/mac.cpp
@@ -64,8 +64,8 @@ namespace ex2 {
       m_firstFragmentReceived = false;
 
       m_currentPacketLength = 0;
-      m_mpduCount = 0;
-      m_expectedMPDUs = 0;
+      m_mpduCodewordFragmentCount = 0;
+      m_numExpectedMpduCodewordFragments = 0;
 
       // @todo clear buffers?
       m_codewordBuffer.resize(0);
@@ -99,19 +99,20 @@ namespace ex2 {
       try {
         MPDU mpdu(*m_errorCorrection, p);
 
-        // @todo Could do some header checks in case we are unlucky. Check packet length is >= 0, for example
+        // A common reason making an MPDU will fail and throw an exception is
+        // that the packet header information is corrupt. We rely on the
+        // MPDUHeader class to check that, including that the error correction
+        // scheme in the header is consistent with the current one in use.
 
-        // The first MPDU transmitted may have a header in it, which is
-        // necessary to make the full packet. Without it, there is no point
-        // in making an application packet so we keep track of its reception.
+        // If we already have the first MPDU, we are looking for more...
         if (m_firstFragmentReceived) {
           // If we are here, we expected more raw MPDUs.
 
           // If the received raw MPDU index matches the current count, this is
-          // the next raw MPDU we expected.
-          if (mpdu.getMpduHeader()->getCodewordFragmentIndex() == m_mpduCount) {
-            m_expectedMPDUs = MPDU::mpdusInNBytes(m_currentPacketLength, *m_errorCorrection);
-            m_mpduCount++;
+          // the next MPDU we expected.
+          if (mpdu.getMpduHeader()->getCodewordFragmentIndex() == m_mpduCodewordFragmentCount) {
+            m_numExpectedMpduCodewordFragments = MPDU::mpdusInNBytes(m_currentPacketLength, *m_errorCorrection);
+            m_mpduCodewordFragmentCount++;
 
             // append to the codewordBuffer this MPDU payload, which may contain
             // some part of a codeword or multiple codewords (remembering
@@ -119,37 +120,82 @@ namespace ex2 {
             m_codewordBuffer.insert(m_codewordBuffer.end(),mpdu.getPayload().begin(),mpdu.getPayload().end());
           }
           else {
-            // The received raw MPDU index is not what we expected, which implies
-            // that a transparent mode packet got dropped somehow
-            // There are two cases to consider.
-            // a) the index is 0 and somehow we have started to receive a new packet, or
-            // b) the index is greater than what we expected, or
-            // c) the index is less than what we expected
+            // The received MPDU index is not what we expected, which implies
+            // that a one or more MPDUs got dropped somehow.
             //
-            // If it is, we need to pad m_codewordBuffer to catch things up
-            if ((mpdu.getMpduHeader()->getCodewordFragmentIndex() > m_mpduCount) &&
-                (mpdu.getMpduHeader()->getCodewordFragmentIndex() <= m_expectedMPDUs)) {
-              uint32_t numMissingMPDUs = mpdu.getMpduHeader()->getCodewordFragmentIndex() - m_mpduCount;
-              // We need to first zero-fill the numMissingMPDUs, then insert
-              // the payload from the one just received.
-              m_codewordBuffer.insert(m_codewordBuffer.end(), numMissingMPDUs * MPDU::maxMTU(), 0);
-              m_codewordBuffer.insert(m_codewordBuffer.end(),mpdu.getPayload().begin(),mpdu.getPayload().end());
-              m_mpduCount = mpdu.getMpduHeader()->getCodewordFragmentIndex() + 1;
-            }
-            else {
-              // Ack, the raw MPDUs are out of order, which should not happen
-              // unless we missed several transparent mode packets. All we can
-              // do is reset
-              m_firstFragmentReceived = false;
-              m_mpduCount = 0;
+            // There are 4 cases to consider.
+            // 1) the index is 0 and somehow we have started to receive a new packet, or
+            // 2) the index is greater than expected, but less than or equal the total expected, or
+            // 3) the index is less than expected, or
+            // 4) the index is more than the total expected
+            //
+
+            //
+            // Case 1) The fragment index is 0, but we already have the first fragment
+            //
+            if (mpdu.getMpduHeader()->getCodewordFragmentIndex() == 0) {
+              //
+              // There is a current packet being built up from MPDUs, so we could
+              // pad it out and decode it, but if the current MPDU is the only
+              // one needed to complete a packet, we'd then have two packets in
+              // hand and no way to return them both, so just ditch the current
+              // packet and start a new one based on the current MPDU.
+              m_processFirstMPDU(mpdu);
+
+              // If only one MPDU is expected for this packet, decode the codeword(s) in the buffer
+              if (m_mpduCodewordFragmentCount == m_numExpectedMpduCodewordFragments) {
+                m_decodePacket();
+                return MAC_UHFPacketProcessingStatus::PACKET_READY;
+              }
+              // Otherwise there must be more MPDUs to come...
+              m_firstFragmentReceived = true;
               return MAC_UHFPacketProcessingStatus::READY_FOR_NEXT_UHF_PACKET;
             }
-          }
+
+            //
+            // Case 2) The fragment index greater than expected, but less than the total expected
+            //
+            // We need to pad m_codewordBuffer to catch things up
+            if ((mpdu.getMpduHeader()->getCodewordFragmentIndex() > m_mpduCodewordFragmentCount) &&
+                (mpdu.getMpduHeader()->getCodewordFragmentIndex() <= m_numExpectedMpduCodewordFragments)) {
+              uint32_t numMissingMPDUs = mpdu.getMpduHeader()->getCodewordFragmentIndex() - m_mpduCodewordFragmentCount;
+              // We need to first zero-fill the numMissingMPDUs, then insert
+              // the payload from the MPDU just received.
+              m_codewordBuffer.insert(m_codewordBuffer.end(), numMissingMPDUs * MPDU::maxMTU(), 0);
+              m_codewordBuffer.insert(m_codewordBuffer.end(), mpdu.getPayload().begin(), mpdu.getPayload().end());
+              // Don't forget to update the count of fragments...
+              m_mpduCodewordFragmentCount = mpdu.getMpduHeader()->getCodewordFragmentIndex() + 1;
+            }
+            else if ((mpdu.getMpduHeader()->getCodewordFragmentIndex() < m_mpduCodewordFragmentCount) ||
+                (mpdu.getMpduHeader()->getCodewordFragmentIndex() > m_numExpectedMpduCodewordFragments)) {
+              //
+              // Case 3) The fragment index less than we expected
+              //
+              // Ack, the raw MPDUs are out of order, which should not happen
+              // unless we also missed the first MPDU of the next packet.
+              // The best we can do is zero-pad the current packet and return it.
+              //
+              // Case 4) The fragment index is more than the total expected
+              //
+              // We have a current packet in progress so we might as well
+              // pad it out, decode, and return it. Clearly the current MPDU
+              // can't be matched up with anything we know about, so we'll
+              // just start looking for a new, first MPDU
+
+              // Calculate the numMissingMPDUs
+              uint32_t numMissingMPDUs = m_numExpectedMpduCodewordFragments - m_mpduCodewordFragmentCount;
+              m_codewordBuffer.insert(m_codewordBuffer.end(), numMissingMPDUs * MPDU::maxMTU(), 0);
+
+              m_decodePacket();
+              return MAC_UHFPacketProcessingStatus::PACKET_READY;
+            }
+
+          } // MPDU fragement index is not what was expected
 
           // Do we have enough raw MPDUs?
           // @todo refactor to avoid duplicate code
-          m_expectedMPDUs = MPDU::mpdusInNBytes(m_currentPacketLength, *m_errorCorrection);
-          if (m_mpduCount == m_expectedMPDUs) {
+          m_numExpectedMpduCodewordFragments = MPDU::mpdusInNBytes(m_currentPacketLength, *m_errorCorrection);
+          if (m_mpduCodewordFragmentCount == m_numExpectedMpduCodewordFragments) {
             m_decodePacket();
             return MAC_UHFPacketProcessingStatus::PACKET_READY;
           } // Have all the MPDUs?
@@ -157,43 +203,21 @@ namespace ex2 {
         }
         else {
 
-          // Check if the first application packet fragment
+          // Check if the first MPDU
           if (mpdu.getMpduHeader()->getCodewordFragmentIndex() == 0) {
-            // Make note of the FEC scheme and check against current.
-            // @todo Not sure this is a great idea since it could lead to being locked out.
-            // For example, satellite is set to one FEC method, ground station tries to
-            // command using a different one and never hears back...
-            if (mpdu.getMpduHeader()->getErrorCorrectionScheme() != m_errorCorrection->getErrorCorrectionScheme()) {
-              // Don't update any counters and such as we are still waiting for
-              // a first fragment with the right FEC scheme
-              return MAC_UHFPacketProcessingStatus::READY_FOR_NEXT_UHF_PACKET;
+
+            m_processFirstMPDU(mpdu);
+
+            // If only one MPDU is expected for this packet, decode the codeword(s) in the buffer
+            if (m_mpduCodewordFragmentCount == m_numExpectedMpduCodewordFragments) {
+              m_decodePacket();
+              return MAC_UHFPacketProcessingStatus::PACKET_READY;
             }
-            else {
-              // We keep in mind that the MPDU header only has the user payload
-              // length when we set the current packet length
-              // @todo what if the header decoded with errors? Need to do subsequent checking!
-              m_currentPacketLength = mpdu.getMpduHeader()->getUserPacketPayloadLength();
-
-              m_expectedMPDUs = MPDU::mpdusInNBytes(m_currentPacketLength, *m_errorCorrection);
-              m_mpduCount++;
-
-              // save this MPDU payload that may contain some part of a codeword
-              // or multiple codewords (remembering codewords are packed into
-              // one or more consecutive MPDUs)
-              m_codewordBuffer.reserve(m_expectedMPDUs*MPDU::maxMTU());
-              m_codewordBuffer.assign(mpdu.getPayload().begin(),mpdu.getPayload().end());
-
-              // If only one MPDU is expected for this packet, decode the codeword(s) in the buffer
-              if (m_mpduCount == m_expectedMPDUs) {
-                m_decodePacket();
-                return MAC_UHFPacketProcessingStatus::PACKET_READY;
-              }
-              m_firstFragmentReceived = true;
-              return MAC_UHFPacketProcessingStatus::READY_FOR_NEXT_UHF_PACKET;
-            }
-
-          }
-          else {
+            // Otherwise there must be more MPDUs to come...
+            m_firstFragmentReceived = true;
+            return MAC_UHFPacketProcessingStatus::READY_FOR_NEXT_UHF_PACKET;
+          } // if first MPDU codeword fragment
+          else { // @note empty else is so we can show the MPDU reconstruction logic
             // If we don't receive the first MPDU for a user packet, we have to
             // wait for the next MPDU. If we have already received the first
             // MPDU for a user packet, we should not be here...
@@ -202,34 +226,76 @@ namespace ex2 {
           return MAC_UHFPacketProcessingStatus::READY_FOR_NEXT_UHF_PACKET;
         }
 
-      }
+      } // try to make a good MPDU
       catch (const MPDUException& e) {
         // @todo log this exception
         printf("MPDU packet exception %s\n", e.what());
 
+        // We are here because the data just received did not result in a valid
+        // MPDU. That means that none of our tracking variables has been updated,
+        // which means there is not much we can do if, for example, the data
+        // just received was a "middle" MPDU.
+
         // If we already have the first fragment, then continue even if the
-        // header was bad
+        // most recent raw MPDU was bad
         if (m_firstFragmentReceived) {
-          // we did receive a codeword  or codeword fragment, but it's junk since
+          // We did receive a codeword fragment, but it's junk since
           // there was a problem making the MPDU. Increment the count of received
           // MPDUs.
-          m_mpduCount++;
+          m_mpduCodewordFragmentCount++;
           // Maybe this is the final expected MPDU? Better check.
-          if (m_mpduCount == m_expectedMPDUs) {
+          if (m_mpduCodewordFragmentCount == m_numExpectedMpduCodewordFragments) {
+            // We have to pad out the current buffer of received MPDUs and
+            // can't use the MPDU that was supposed to correspond to the just
+            // received data.
+            // Calculate the numMissingMPDUs, which should be 1, but let's be explicit.
+            uint32_t numMissingMPDUs = m_numExpectedMpduCodewordFragments - (m_mpduCodewordFragmentCount - 1);
+            m_codewordBuffer.insert(m_codewordBuffer.end(), numMissingMPDUs * MPDU::maxMTU(), 0);
+
             m_decodePacket();
             return MAC_UHFPacketProcessingStatus::PACKET_READY;
           } // Have all the MPDUs?
+
+          // If it was not the final fragment expected, just continue...
         }
-        else {
-          // If the first user packet fragment has not yet been received, then
-          // we can't tell if this failed MPDU was supposed to be it, so all
-          // we can do is continue to look for a first MPDU
-          return MAC_UHFPacketProcessingStatus::READY_FOR_NEXT_UHF_PACKET;
-        }
-      }
+
+        // If the first user packet fragment has not yet been received, then
+        // we can't tell if this failed MPDU was supposed to be it, so all
+        // we can do is continue to look for a first MPDU; fall through
+
+      } // catch
 
       return MAC_UHFPacketProcessingStatus::READY_FOR_NEXT_UHF_PACKET;
     } // processUHFPacket
+
+    void
+    MAC::m_processFirstMPDU(MPDU &firstMPDU) {
+      // The first MPDU transmitted may have a user packet header in it, which
+      // is necessary at the application layer to make the full packet.
+      // Without it, there is no point in making an application packet so we
+      // keep track of its reception.
+
+      // Assume the first MPDU has correct information in its header.
+      // Save it so we can keep track of the remaining MPDUs needed to
+      // complete the user packet and do some error handling for things
+      // like missing packets.
+      //
+      // @todo what if the header decoded with errors we don't catch?
+      // @todo We could to more checking!? However, chances are a
+      // subsequent packet will have the right information and cause one
+      // of the error handling mechanisms to terminate the current packet
+      // reconstruction.
+
+      m_currentPacketLength = firstMPDU.getMpduHeader()->getUserPacketPayloadLength();
+      m_numExpectedMpduCodewordFragments = MPDU::mpdusInNBytes(m_currentPacketLength, *m_errorCorrection);
+      m_mpduCodewordFragmentCount = 1;
+
+      // save this MPDU payload that may contain some part of a codeword
+      // or multiple codewords (remembering codewords are packed into
+      // one or more consecutive MPDUs)
+      m_codewordBuffer.reserve(m_numExpectedMpduCodewordFragments*MPDU::maxMTU());
+      m_codewordBuffer.assign(firstMPDU.getPayload().begin(),firstMPDU.getPayload().end());
+    }
 
     void
     MAC::m_decodePacket() {
@@ -248,7 +314,7 @@ namespace ex2 {
       }
       m_rawPacket.resize(m_currentPacketLength);
       m_firstFragmentReceived = false;
-      m_mpduCount = 0;
+      m_mpduCodewordFragmentCount = 0;
     }
 
     bool
@@ -292,7 +358,7 @@ namespace ex2 {
       std::vector<uint8_t> mpduPayload;
       mpduPayload.resize(0); // ensure it's empty
       uint32_t mpduPayloadBytesRemaining = MPDU::maxMTU();
-      uint32_t mpduCount = 0;
+      uint32_t mpduCodewordFragmentCount = 0;
 
       m_transparentModePayloads.resize(0);
 
@@ -349,7 +415,7 @@ namespace ex2 {
             // only possible error would be from a bad ErrorCorrection, but that
             // would have been caught when m_errorCorrection was made.
             MPDUHeader *mpduHeader = new MPDUHeader(m_rfModeNumber, *m_errorCorrection,
-              mpduCount++, packetLength, 0);
+              mpduCodewordFragmentCount++, packetLength, 0);
             // Make an MPDU.
             // Just the same as for the MPDUHeader, there is no way for this
             // constructor to generate an exception because the only check that
@@ -395,7 +461,7 @@ namespace ex2 {
         // only possible error would be from a bad ErrorCorrection, but that
         // would have been caught when m_errorCorrection was made.
         MPDUHeader *mpduHeader = new MPDUHeader(m_rfModeNumber, *m_errorCorrection,
-          mpduCount++, packetLength, 0);
+          mpduCodewordFragmentCount++, packetLength, 0);
         // Make an MPDU.
         // Just the same as for the MPDUHeader, there is no way for this
         // constructor to generate an exception because the only check that

--- a/lib/mac_layer/pdu/mpdu.cpp
+++ b/lib/mac_layer/pdu/mpdu.cpp
@@ -13,6 +13,7 @@
 
 #include "mpdu.hpp"
 
+#define MPDU_DEBUG 0 // set to 1 for debug output
 namespace ex2
 {
   namespace sdr
@@ -93,7 +94,9 @@ namespace ex2
       }
       catch (MPDUHeaderException& e) {
         // @todo should log this
+//#if MPDU_DEBUG
         printf("MPDUHeader exception : %s\n", e.what());
+//#endif
         throw MPDUException("MPDU: Bad raw MPDUHeader.");
       }
 

--- a/lib/mac_layer/pdu/mpdu.cpp
+++ b/lib/mac_layer/pdu/mpdu.cpp
@@ -47,6 +47,7 @@ namespace ex2
     }
 
     MPDU::MPDU (
+      const ErrorCorrection &currentErrorCorrection,
       std::vector<uint8_t>& rawMPDU) {
 
       // There are several possibilities for received @p rawMPDU:
@@ -76,7 +77,7 @@ namespace ex2
       // >
 
       try {
-        m_mpduHeader = new MPDUHeader(rawMPDU);
+        m_mpduHeader = new MPDUHeader(currentErrorCorrection, rawMPDU);
 
         // Header seems okay, so make codeword based on how many remaining bytes
         // in rawMPDU

--- a/lib/mac_layer/pdu/mpduHeader.cpp
+++ b/lib/mac_layer/pdu/mpduHeader.cpp
@@ -52,7 +52,6 @@ namespace ex2 {
 
       if (rawHeader.size() < (k_MACHeaderLength / 8)) {
         throw MPDUHeaderException("MPDUHeader: Raw header too short");
-
       }
       try {
         if (decodeMACHeader(rawHeader)) {

--- a/lib/mac_layer/pdu/mpduHeader.cpp
+++ b/lib/mac_layer/pdu/mpduHeader.cpp
@@ -184,7 +184,7 @@ namespace ex2 {
       // boudaries, so a bit of bit shifting is needed to get things right.
       uint16_t msgBits = ((uint16_t) m_rfModeNumber << 9) & 0x0E00; // 3 bits
       msgBits = msgBits | (((uint16_t) m_errorCorrection->getErrorCorrectionScheme() << 3) & 0x01F8); // 6 bits
-      msgBits = msgBits | ((m_codewordFragmentIndex >> 4) & 0x0007); // bottom 3 bits
+      msgBits = msgBits | ((m_codewordFragmentIndex >> 4) & 0x0007); // top, MSB 3 bits
 
       uint32_t codeword = golay_encode(msgBits);
 
@@ -193,8 +193,8 @@ namespace ex2 {
       m_headerPayload[0] = (uint8_t)((codeword & 0x00FF0000) >> 16);
 
       msgBits = 0;
-      msgBits = (m_codewordFragmentIndex << 8) & 0x00000F00;        // top 4 bits
-      msgBits = msgBits | ((m_userPacketPayloadLength >> 4) & 0x000000FF); // bottom 8 bits
+      msgBits = (m_codewordFragmentIndex << 8) & 0x00000F00;               // bottom, LSB 4 bits
+      msgBits = msgBits | ((m_userPacketPayloadLength >> 4) & 0x000000FF); // top, MSB 8 bits
 
       codeword = golay_encode(msgBits);
 
@@ -203,8 +203,8 @@ namespace ex2 {
       m_headerPayload[3] = (uint8_t)((codeword & 0x00FF0000) >> 16);
 
       msgBits = 0;
-      msgBits = (m_userPacketPayloadLength << 8) & 0x00000F00;
-      msgBits = msgBits | (m_userPacketFragmentIndex & 0x000000FF);
+      msgBits = (m_userPacketPayloadLength << 8) & 0x00000F00;      // bottom, LSB 4 bits
+      msgBits = msgBits | (m_userPacketFragmentIndex & 0x000000FF); // all 8 bits
 
       codeword = golay_encode(msgBits);
 

--- a/unit_tests/qa_golay.cpp
+++ b/unit_tests/qa_golay.cpp
@@ -133,11 +133,22 @@ TEST(golay, CheckManyUncorrectableErrors )
       // Apply the bit error tothe codeword to get received codeword
       uint32_t recd = codeword ^ pattern;
 #if QA_GLOAY_DEBUG
-      printf("pattern 0x%08x codeword 0x%08x recd 0x%08x\n", pattern, codeword, recd);
+      printf("numBitErrors %d pattern 0x%08x codeword 0x%08x recd 0x%08x\n", numBitErrors, pattern, codeword, recd);
 #endif
       // Decode
       int16_t decoded = golay_decode(recd);
 #if QA_GLOAY_DEBUG
+      if (decoded < 0) {
+        printf("detected 4 errors for numBitErrors = %d\n",numBitErrors);
+      }
+      int32_t errors = golay_errors(recd);
+      if (errors < 0) {
+        printf("golay_errors returned < 0 0x%04x for numBitErrors = %d\n",errors, numBitErrors);
+      }
+      else {
+        printf("golay_errors returned 0x%04x for numBitErrors = %d\n",errors, numBitErrors);
+      }
+
       printf(" lots errors decoded = %d\n",decoded);
 #endif
       // Check decoded is same as data

--- a/unit_tests/qa_mac.cpp
+++ b/unit_tests/qa_mac.cpp
@@ -28,7 +28,8 @@ using namespace ex2::sdr;
 
 #include "gtest/gtest.h"
 
-#define QA_MAC_DEBUG 0 // set to 1 for debugging output
+#define QA_MAC_DEBUG 0         // set to 1 for debugging output
+#define QA_MAC_VERBOSE_DEBUG 0 // set to 1 for verbose debugging output
 
 // @todo should be 14
 #define NUM_ERROR_CORRECTION_SCHEMES_TO_TEST 14
@@ -285,8 +286,6 @@ TEST(mac, PacketLoopbackNoDroppedPackets) {
                 ASSERT_TRUE(same) << "decoded packet does not match original";
               }
               break;
-              case MAC::MAC_UHFPacketProcessingStatus::PACKET_READY_RESUBMIT_PREVIOUS_PACKET:
-                break;
               case MAC::MAC_UHFPacketProcessingStatus::READY_FOR_NEXT_UHF_PACKET:
                 break;
               default:
@@ -491,8 +490,6 @@ TEST(mac, PacketLoopbackDroppedPackets) {
                 FAIL() << "a packet was made without the first MPDU; this cannot happen";
               }
               break;
-              case MAC::MAC_UHFPacketProcessingStatus::PACKET_READY_RESUBMIT_PREVIOUS_PACKET:
-                break;
               case MAC::MAC_UHFPacketProcessingStatus::READY_FOR_NEXT_UHF_PACKET:
                 break;
               default:
@@ -521,8 +518,6 @@ TEST(mac, PacketLoopbackDroppedPackets) {
                   ASSERT_FALSE(same) << "decoded packet matches original even though an MPDU was dropped";
                 }
                 break;
-                case MAC::MAC_UHFPacketProcessingStatus::PACKET_READY_RESUBMIT_PREVIOUS_PACKET:
-                  break;
                 case MAC::MAC_UHFPacketProcessingStatus::READY_FOR_NEXT_UHF_PACKET:
                   break;
                 default:
@@ -555,8 +550,6 @@ TEST(mac, PacketLoopbackDroppedPackets) {
                 ASSERT_FALSE(same) << "decoded packet matches original even though an MPDU was mangled";
               }
               break;
-              case MAC::MAC_UHFPacketProcessingStatus::PACKET_READY_RESUBMIT_PREVIOUS_PACKET:
-                break;
               case MAC::MAC_UHFPacketProcessingStatus::READY_FOR_NEXT_UHF_PACKET:
                 break;
               default:

--- a/unit_tests/qa_mac.cpp
+++ b/unit_tests/qa_mac.cpp
@@ -34,6 +34,79 @@ using namespace ex2::sdr;
 // @todo should be 14
 #define NUM_ERROR_CORRECTION_SCHEMES_TO_TEST 14
 
+ErrorCorrection::ErrorCorrectionScheme getScheme(int ecScheme) {
+  ErrorCorrection::ErrorCorrectionScheme ecs;
+  switch(ecScheme) {
+    case 0:
+      ecs = ErrorCorrection::ErrorCorrectionScheme::NO_FEC;
+      break;
+    case 1:
+      ecs = ErrorCorrection::ErrorCorrectionScheme::IEEE_802_11N_QCLDPC_648_R_1_2;
+      break;
+    case 2:
+      ecs = ErrorCorrection::ErrorCorrectionScheme::IEEE_802_11N_QCLDPC_648_R_2_3;
+      break;
+    case 3:
+      ecs = ErrorCorrection::ErrorCorrectionScheme::IEEE_802_11N_QCLDPC_648_R_3_4;
+      break;
+    case 4:
+      ecs = ErrorCorrection::ErrorCorrectionScheme::IEEE_802_11N_QCLDPC_648_R_5_6;
+      break;
+    case 5:
+      ecs = ErrorCorrection::ErrorCorrectionScheme::IEEE_802_11N_QCLDPC_1296_R_1_2;
+      break;
+    case 6:
+      ecs = ErrorCorrection::ErrorCorrectionScheme::IEEE_802_11N_QCLDPC_1296_R_2_3;
+      break;
+    case 7:
+      ecs = ErrorCorrection::ErrorCorrectionScheme::IEEE_802_11N_QCLDPC_1296_R_3_4;
+      break;
+    case 8:
+      ecs = ErrorCorrection::ErrorCorrectionScheme::IEEE_802_11N_QCLDPC_1296_R_5_6;
+      break;
+    case 9:
+      ecs = ErrorCorrection::ErrorCorrectionScheme::IEEE_802_11N_QCLDPC_1944_R_1_2;
+      break;
+    case 10:
+      ecs = ErrorCorrection::ErrorCorrectionScheme::IEEE_802_11N_QCLDPC_1944_R_2_3;
+      break;
+    case 11:
+      ecs = ErrorCorrection::ErrorCorrectionScheme::IEEE_802_11N_QCLDPC_1944_R_3_4;
+      break;
+    case 12:
+      ecs = ErrorCorrection::ErrorCorrectionScheme::IEEE_802_11N_QCLDPC_1944_R_5_6;
+      break;
+    case 13:
+      ecs = ErrorCorrection::ErrorCorrectionScheme::CCSDS_CONVOLUTIONAL_CODING_R_1_2;
+      break;
+    case 14:
+      ecs = ErrorCorrection::ErrorCorrectionScheme::CCSDS_CONVOLUTIONAL_CODING_R_2_3;
+      break;
+    case 15:
+      ecs = ErrorCorrection::ErrorCorrectionScheme::CCSDS_CONVOLUTIONAL_CODING_R_3_4;
+      break;
+    case 16:
+      ecs = ErrorCorrection::ErrorCorrectionScheme::CCSDS_CONVOLUTIONAL_CODING_R_5_6;
+      break;
+    case 17:
+      ecs = ErrorCorrection::ErrorCorrectionScheme::CCSDS_CONVOLUTIONAL_CODING_R_7_8;
+      break;
+    default:
+      ecs = ErrorCorrection::ErrorCorrectionScheme::NO_FEC;
+      break;
+  }
+  return ecs;
+} // getScheme
+
+uint8_t * makePacket(uint16_t length) {
+  uint8_t * packet = (uint8_t *) malloc(length);
+
+  for (unsigned long i = 0; i < length; i++) {
+    packet[i] = (i % 79) + 0x30; // ASCII numbers through to ~
+  }
+  return packet;
+}
+
 /*!
  * @brief Test constructor
  */
@@ -122,8 +195,6 @@ TEST(mac, PacketLoopbackNoDroppedPackets) {
   // Specifically, let's try the NO_FEC, CCSDS Convolutional Coders, and IEEE
   // 802.11 QCLDPC since they are what we plan to use at a minimum.
 
-  // Note: The QCLDPC is not actually implemented as of 202205
-
   int const numSchemes = 18;
   uint16_t expectedMPDUs[numSchemes][numPackets] = {
     {1,1,1,4,35}, // NO_FEC, m = n = 119
@@ -148,101 +219,30 @@ TEST(mac, PacketLoopbackNoDroppedPackets) {
 
   // @note, not all schemes are currently supported; the QCLDPC are stubbed for
   // now, and all but the rate 1/2 convolutional coding schemes are skipped.
-  ErrorCorrection::ErrorCorrectionScheme ecs;
 
   for (int ecScheme = 0; ecScheme < NUM_ERROR_CORRECTION_SCHEMES_TO_TEST; ecScheme++) {
 
-    switch(ecScheme) {
-      case 0:
-        ecs = ErrorCorrection::ErrorCorrectionScheme::NO_FEC;
-        break;
-      case 1:
-        ecs = ErrorCorrection::ErrorCorrectionScheme::IEEE_802_11N_QCLDPC_648_R_1_2;
-        break;
-      case 2:
-        ecs = ErrorCorrection::ErrorCorrectionScheme::IEEE_802_11N_QCLDPC_648_R_2_3;
-        break;
-      case 3:
-        ecs = ErrorCorrection::ErrorCorrectionScheme::IEEE_802_11N_QCLDPC_648_R_3_4;
-        break;
-      case 4:
-        ecs = ErrorCorrection::ErrorCorrectionScheme::IEEE_802_11N_QCLDPC_648_R_5_6;
-        break;
-      case 5:
-        ecs = ErrorCorrection::ErrorCorrectionScheme::IEEE_802_11N_QCLDPC_1296_R_1_2;
-        break;
-      case 6:
-        ecs = ErrorCorrection::ErrorCorrectionScheme::IEEE_802_11N_QCLDPC_1296_R_2_3;
-        break;
-      case 7:
-        ecs = ErrorCorrection::ErrorCorrectionScheme::IEEE_802_11N_QCLDPC_1296_R_3_4;
-        break;
-      case 8:
-        ecs = ErrorCorrection::ErrorCorrectionScheme::IEEE_802_11N_QCLDPC_1296_R_5_6;
-        break;
-      case 9:
-        ecs = ErrorCorrection::ErrorCorrectionScheme::IEEE_802_11N_QCLDPC_1944_R_1_2;
-        break;
-      case 10:
-        ecs = ErrorCorrection::ErrorCorrectionScheme::IEEE_802_11N_QCLDPC_1944_R_2_3;
-        break;
-      case 11:
-        ecs = ErrorCorrection::ErrorCorrectionScheme::IEEE_802_11N_QCLDPC_1944_R_3_4;
-        break;
-      case 12:
-        ecs = ErrorCorrection::ErrorCorrectionScheme::IEEE_802_11N_QCLDPC_1944_R_5_6;
-        break;
-      case 13:
-        ecs = ErrorCorrection::ErrorCorrectionScheme::CCSDS_CONVOLUTIONAL_CODING_R_1_2;
-        break;
-      case 14:
-        ecs = ErrorCorrection::ErrorCorrectionScheme::CCSDS_CONVOLUTIONAL_CODING_R_2_3;
-        break;
-      case 15:
-        ecs = ErrorCorrection::ErrorCorrectionScheme::CCSDS_CONVOLUTIONAL_CODING_R_3_4;
-        break;
-      case 16:
-        ecs = ErrorCorrection::ErrorCorrectionScheme::CCSDS_CONVOLUTIONAL_CODING_R_5_6;
-        break;
-      case 17:
-        ecs = ErrorCorrection::ErrorCorrectionScheme::CCSDS_CONVOLUTIONAL_CODING_R_7_8;
-        break;
-      default:
-        ecs = ErrorCorrection::ErrorCorrectionScheme::NO_FEC;
-        break;
-    }
+    ErrorCorrection::ErrorCorrectionScheme ecs  = getScheme(ecScheme);
 
     // Set the current ECS in the MAC object
     myMac1->setErrorCorrectionScheme(ecs);
 
     for (uint16_t currentPacket = 0; currentPacket < numPackets; currentPacket++) {
 
-      // Make a packet for the current length
+      // Make a user packet for the current length
+      uint8_t * packet = makePacket(packetDataLengths[currentPacket]);
+      ASSERT_FALSE(packet == NULL) << "Failed to get packet buffer";
 
-      uint8_t * packet = (uint8_t *) malloc(packetDataLengths[currentPacket]);
-
-      if (packet == NULL) {
-        printf("Failed to get packet buffer\n");
-      }
-
-      // Set the payload to readable ASCII
-      for (unsigned long i = 0; i < packetDataLengths[currentPacket]; i++) {
-        packet[i] = (i % 79) + 0x30; // ASCII numbers through to ~
-      }
-
-      // Process a packet
+      // Process a user packet
       bool packetEncoded = myMac1->receivePacket(packet, packetDataLengths[currentPacket]);
-
       ASSERT_TRUE(packetEncoded) << "Failed to encode packet ";
 
       uint32_t totalPayloadsBytes = myMac1->mpduPayloadsBufferLength();
-      uint32_t rawMPDULength = MPDU::rawMPDULength();
+      ASSERT_TRUE((totalPayloadsBytes % MPDU::rawMPDULength()) == 0) << "The raw payloads buffer must be an integer multiple of the raw MPDU length.";
 
-      ASSERT_TRUE((totalPayloadsBytes % rawMPDULength) == 0) << "The raw payloads buffer must be an integer multiple of the raw MPDU length.";
-
-      const uint32_t numMPDUs = totalPayloadsBytes / rawMPDULength;
+      const uint32_t numMPDUs = totalPayloadsBytes / MPDU::rawMPDULength();
 #if QA_MAC_DEBUG
-      printf("Raw MPDU length = %d\n", rawMPDULength);
+      printf("Raw MPDU length = %d\n", MPDU::rawMPDULength());
       printf("totalPayloadsBytes %d\n",totalPayloadsBytes);
       printf("numMPDUS = %d\n", numMPDUs);
       printf("expectedMPDUs[%d][%d] = %d\n",ecScheme,currentPacket,expectedMPDUs[ecScheme][currentPacket]);
@@ -257,44 +257,44 @@ TEST(mac, PacketLoopbackNoDroppedPackets) {
 
       // At this point we get the mpdu buffer and feed it one raw MPDU at a time
       // into myMac1->processUHFPacket(...)
-      if (packetEncoded) {
-        const uint8_t *mpdusBuffer = myMac1->mpduPayloadsBuffer();
+      const uint8_t *mpdusBuffer = myMac1->mpduPayloadsBuffer();
+      ASSERT_FALSE(mpdusBuffer == NULL) << "Failed to get MPDUs buffer";
 
-        // @todo get rid of magic number
-        if (mpdusBuffer && (myMac1->mpduPayloadsBufferLength() % 128 == 0)) {
+      bool recvPacketGood = false;
+      for (uint16_t rawMPDUCount = 0; rawMPDUCount < numMPDUs; rawMPDUCount++) {
+        MAC::MAC_UHFPacketProcessingStatus status = myMac1->processUHFPacket(mpdusBuffer+rawMPDUCount*MPDU::rawMPDULength(), MPDU::rawMPDULength());
 
-          for (uint16_t rawMPDUCount = 0; rawMPDUCount < numMPDUs; rawMPDUCount++) {
-            MAC::MAC_UHFPacketProcessingStatus status = myMac1->processUHFPacket(mpdusBuffer+rawMPDUCount*MPDU::rawMPDULength(), MPDU::rawMPDULength());
-
-            switch (status) {
-              case MAC::MAC_UHFPacketProcessingStatus::PACKET_READY:
-              {
-                const uint8_t *rawPacket = myMac1->getRawPacketBuffer();
+        switch (status) {
+          case MAC::MAC_UHFPacketProcessingStatus::PACKET_READY:
+          {
+            const uint8_t *rawPacket = myMac1->getRawPacketBuffer();
 
 #if QA_MAC_DEBUG
-                printf("original packet length %ld raw packet length %d \n",
-                  packetDataLengths[currentPacket], myMac1->getRawPacketBufferLength());
-                for (uint16_t i = 0; i < myMac1->getRawPacketLength(); i++) {
-                  printf("%04d %02x|%02x\n",i,rawPacket[i],packet[i]);
-                }
-                printf("------------\n");
+            printf("original packet length %ld raw packet length %d \n",
+              packetDataLengths[currentPacket], myMac1->getRawPacketBufferLength());
+            for (uint16_t i = 0; i < myMac1->getRawPacketLength(); i++) {
+              printf("%04d %02x|%02x\n",i,rawPacket[i],packet[i]);
+            }
+            printf("------------\n");
 #endif
-                bool same = true;
-                for (uint16_t i = 0; same && (i < myMac1->getRawPacketLength()); i++) {
-                  same = same && (rawPacket[i] == packet[i]);
-                }
-                ASSERT_TRUE(same) << "decoded packet does not match original";
-              }
-              break;
-              case MAC::MAC_UHFPacketProcessingStatus::READY_FOR_NEXT_UHF_PACKET:
-                break;
-              default:
-                break;
-            } // switch on returned UHF packet process status
+            bool same = true;
+            for (uint16_t i = 0; same && (i < myMac1->getRawPacketLength()); i++) {
+              same = same && (rawPacket[i] == packet[i]);
+            }
+            recvPacketGood = same;
+            ASSERT_TRUE(same) << "decoded packet does not match original";
+          }
+          break;
+          case MAC::MAC_UHFPacketProcessingStatus::READY_FOR_NEXT_UHF_PACKET:
+            break;
+          default:
+            break;
+        } // switch on returned UHF packet process status
 
-          } // for all the raw MPDUs
-        } // check if have an integral number of raw MPDUs
-      } // was the packet successfully encoded
+      } // for all the raw MPDUs
+
+      ASSERT_TRUE(recvPacketGood) << "The expected packet was not received.";
+
 
       // Clean up!
       free(packet);
@@ -322,10 +322,6 @@ TEST(mac, PacketLoopbackDroppedPackets) {
    * A wrinkle is that if the first MPDU goes missing (is corrupted), then we
    * give up on the packet entirely.
    *
-   * @todo do we need to actually give up?
-   *
-   * We might think that it's not necessary to test all the error correction
-   * schemes, but why not?
    * ---------------------------------------------------------------------
    */
 
@@ -373,193 +369,440 @@ TEST(mac, PacketLoopbackDroppedPackets) {
 
   // @note, not all schemes are currently supported; the QCLDPC are stubbed for
   // now, and all but the rate 1/2 convolutional coding schemes are skipped.
-  ErrorCorrection::ErrorCorrectionScheme ecs;
   std::vector<int> schemes({0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 12, 13});
 
   for (int ecScheme : schemes) {
 
-    switch(ecScheme) {
-      case 0:
-        ecs = ErrorCorrection::ErrorCorrectionScheme::NO_FEC;
-        break;
-      case 1:
-        ecs = ErrorCorrection::ErrorCorrectionScheme::IEEE_802_11N_QCLDPC_648_R_1_2;
-        break;
-      case 2:
-        ecs = ErrorCorrection::ErrorCorrectionScheme::IEEE_802_11N_QCLDPC_648_R_2_3;
-        break;
-      case 3:
-        ecs = ErrorCorrection::ErrorCorrectionScheme::IEEE_802_11N_QCLDPC_648_R_3_4;
-        break;
-      case 4:
-        ecs = ErrorCorrection::ErrorCorrectionScheme::IEEE_802_11N_QCLDPC_648_R_5_6;
-        break;
-      case 5:
-        ecs = ErrorCorrection::ErrorCorrectionScheme::IEEE_802_11N_QCLDPC_1296_R_1_2;
-        break;
-      case 6:
-        ecs = ErrorCorrection::ErrorCorrectionScheme::IEEE_802_11N_QCLDPC_1296_R_2_3;
-        break;
-      case 7:
-        ecs = ErrorCorrection::ErrorCorrectionScheme::IEEE_802_11N_QCLDPC_1296_R_3_4;
-        break;
-      case 8:
-        ecs = ErrorCorrection::ErrorCorrectionScheme::IEEE_802_11N_QCLDPC_1296_R_5_6;
-        break;
-      case 9:
-        ecs = ErrorCorrection::ErrorCorrectionScheme::IEEE_802_11N_QCLDPC_1944_R_1_2;
-        break;
-      case 10:
-        ecs = ErrorCorrection::ErrorCorrectionScheme::IEEE_802_11N_QCLDPC_1944_R_2_3;
-        break;
-      case 11:
-        ecs = ErrorCorrection::ErrorCorrectionScheme::IEEE_802_11N_QCLDPC_1944_R_3_4;
-        break;
-      case 12:
-        ecs = ErrorCorrection::ErrorCorrectionScheme::IEEE_802_11N_QCLDPC_1944_R_5_6;
-        break;
-      case 13:
-        ecs = ErrorCorrection::ErrorCorrectionScheme::CCSDS_CONVOLUTIONAL_CODING_R_1_2;
-        break;
-      case 14:
-        ecs = ErrorCorrection::ErrorCorrectionScheme::CCSDS_CONVOLUTIONAL_CODING_R_2_3;
-        break;
-      case 15:
-        ecs = ErrorCorrection::ErrorCorrectionScheme::CCSDS_CONVOLUTIONAL_CODING_R_3_4;
-        break;
-      case 16:
-        ecs = ErrorCorrection::ErrorCorrectionScheme::CCSDS_CONVOLUTIONAL_CODING_R_5_6;
-        break;
-      case 17:
-        ecs = ErrorCorrection::ErrorCorrectionScheme::CCSDS_CONVOLUTIONAL_CODING_R_7_8;
-        break;
-      default:
-        ecs = ErrorCorrection::ErrorCorrectionScheme::NO_FEC;
-        break;
-    }
+    ErrorCorrection::ErrorCorrectionScheme ecs  = getScheme(ecScheme);
 
     // Set the current ECS in the MAC object
     myMac1->setErrorCorrectionScheme(ecs);
 
     for (uint16_t currentPacket = 0; currentPacket < numPackets; currentPacket++) {
 
-      // Make a packet for the current length
+      // Make a user packet for the current length
+      uint8_t * packet = makePacket(packetDataLengths[currentPacket]);
+      ASSERT_FALSE(packet == NULL) << "Failed to get packet buffer";
 
-      uint8_t * packet = (uint8_t *) malloc(packetDataLengths[currentPacket]);
-
-      if (packet == NULL) {
-        printf("Failed to get packet buffer\n");
-      }
-
-      for (unsigned long i = 0; i < packetDataLengths[currentPacket]; i++) {
-        packet[i] = (i % 79) + 0x30; // ASCII numbers through to ~
-      }
-
-      // Process a packet
+      // Process a user packet
       bool packetEncoded = myMac1->receivePacket(packet, packetDataLengths[currentPacket]);
-
       ASSERT_TRUE(packetEncoded) << "Failed to encode Packet ";
 
       uint32_t totalPayloadsBytes = myMac1->mpduPayloadsBufferLength();
-      uint32_t rawMPDULength = MPDU::rawMPDULength();
-
       // @note we could skip some ASSERTs here since they are done in the happy
       // path unit test above, but it does not hurt to check
-      ASSERT_TRUE((totalPayloadsBytes % rawMPDULength) == 0) << "The raw payloads buffer must be an integer multiple of the raw MPDU length.";
+      ASSERT_TRUE((totalPayloadsBytes % MPDU::rawMPDULength()) == 0) << "The raw payloads buffer must be an integer multiple of the raw MPDU length.";
 
-      const uint32_t numMPDUs = totalPayloadsBytes / rawMPDULength;
+      const uint32_t numMPDUs = totalPayloadsBytes / MPDU::rawMPDULength();
 
       // Check the number of MPDUs required matches expectations
       ASSERT_TRUE(numMPDUs == expectedMPDUs[ecScheme][currentPacket]) << "Incorrect number of MPDUs for Packet " << numMPDUs;
+      ASSERT_TRUE(numMPDUs >= 4) << "All tests need at least 4 MPDUs";
 
-      // At this point we get the mpdu buffer and feed it one raw MPDU at a time
+      // At this point we get the mpdu buffer.
+      // For the various missing packet scenarios, we feed one or more raw MPDUs
       // into myMac1->processUHFPacket(...)
-      if (packetEncoded) {
-        const uint8_t *mpdusBuffer = myMac1->mpduPayloadsBuffer();
+      const uint8_t *mpdusBuffer = myMac1->mpduPayloadsBuffer();
+      ASSERT_FALSE(mpdusBuffer == NULL) << "Failed to get MPDUs buffer";
 
-        // @todo get rid of magic number
-        if (mpdusBuffer && (myMac1->mpduPayloadsBufferLength() % 128 == 0)) {
+      //////////////////////////////////////////////////////////////////////////
+      // Scenario 1; First raw MPDU is missing, all others received.
+      // Expected result; No packet is produced.
+      //////////////////////////////////////////////////////////////////////////
+#if QA_MAC_VERBOSE_DEBUG
+      printf("Scenario 1; First raw MPDU is missing.\n");
+#endif
+      bool recvPacketGood = false;
+      for (uint16_t rawMPDUCount = 1; rawMPDUCount < numMPDUs; rawMPDUCount++) {
+        MAC::MAC_UHFPacketProcessingStatus status = myMac1->processUHFPacket(mpdusBuffer+rawMPDUCount*MPDU::rawMPDULength(), MPDU::rawMPDULength());
 
-          // Test if missing the first MPDU results in a packet. It should not
-          for (uint16_t rawMPDUCount = 1; rawMPDUCount < numMPDUs; rawMPDUCount++) {
-            MAC::MAC_UHFPacketProcessingStatus status = myMac1->processUHFPacket(mpdusBuffer+rawMPDUCount*MPDU::rawMPDULength(), MPDU::rawMPDULength());
+        switch (status) {
+          case MAC::MAC_UHFPacketProcessingStatus::PACKET_READY:
+          {
+            FAIL() << "a packet was made without the first MPDU; this cannot happen";
+          }
+          break;
+          case MAC::MAC_UHFPacketProcessingStatus::READY_FOR_NEXT_UHF_PACKET:
+            break;
+          default:
+            break;
+        } // switch on returned UHF packet process status
 
-            switch (status) {
-              case MAC::MAC_UHFPacketProcessingStatus::PACKET_READY:
-              {
-                FAIL() << "a packet was made without the first MPDU; this cannot happen";
+      } // for all the raw MPDUs except the first
+
+      ASSERT_FALSE(recvPacketGood) << "Scenario 1; Even though no first raw MPDU, a packet was received.";
+
+      //////////////////////////////////////////////////////////////////////////
+      // Scenario 2; Second raw MPDU is missing, all others received.
+      // Expected result; A packet is produced; it will not be correct, but that
+      // is to be dealt with by an upper layer. Check the packet does not match
+      // the original.
+      //////////////////////////////////////////////////////////////////////////
+#if QA_MAC_VERBOSE_DEBUG
+      printf("Scenario 2; Second raw MPDU is missing.\n");
+#endif
+      recvPacketGood = false;
+      for (uint16_t rawMPDUCount = 0; rawMPDUCount < numMPDUs; rawMPDUCount++) {
+        // skip the second MPDU
+        if (rawMPDUCount != 1) {
+          MAC::MAC_UHFPacketProcessingStatus status = myMac1->processUHFPacket(mpdusBuffer+rawMPDUCount*MPDU::rawMPDULength(), MPDU::rawMPDULength());
+          switch (status) {
+            case MAC::MAC_UHFPacketProcessingStatus::PACKET_READY:
+            {
+              const uint8_t *rawPacket = myMac1->getRawPacketBuffer();
+
+              bool same = true;
+              for (uint16_t i = 0; i < myMac1->getRawPacketLength(); i++) {
+                same = same && (rawPacket[i] == packet[i]);
               }
-              break;
-              case MAC::MAC_UHFPacketProcessingStatus::READY_FOR_NEXT_UHF_PACKET:
-                break;
-              default:
-                break;
-            } // switch on returned UHF packet process status
-
-          } // for all the raw MPDUs except the first
-
-          // Test if missing the second MPDU results in a packet. It should,
-          // and the result should be the correct length, but not match the
-          // original
-//printf("test missing second MPDU\n");
-          for (uint16_t rawMPDUCount = 0; rawMPDUCount < numMPDUs; rawMPDUCount++) {
-            // skip the second MPDU
-            if (rawMPDUCount != 1) {
-              MAC::MAC_UHFPacketProcessingStatus status = myMac1->processUHFPacket(mpdusBuffer+rawMPDUCount*MPDU::rawMPDULength(), MPDU::rawMPDULength());
-              switch (status) {
-                case MAC::MAC_UHFPacketProcessingStatus::PACKET_READY:
-                {
-                  const uint8_t *rawPacket = myMac1->getRawPacketBuffer();
-
-                  bool same = true;
-                  for (uint16_t i = 0; i < myMac1->getRawPacketLength(); i++) {
-                    same = same && (rawPacket[i] == packet[i]);
-                  }
-                  ASSERT_FALSE(same) << "decoded packet matches original even though an MPDU was dropped";
-                }
-                break;
-                case MAC::MAC_UHFPacketProcessingStatus::READY_FOR_NEXT_UHF_PACKET:
-                  break;
-                default:
-                  break;
-              } // switch on returned UHF packet process status
-            } // skip the second MPDU
-          } // for all the raw MPDUs except the second
-
-          // Test if corrupting the second MPDU results in a packet. It should not
-          for (uint16_t rawMPDUCount = 0; rawMPDUCount < numMPDUs; rawMPDUCount++) {
-
-            MAC::MAC_UHFPacketProcessingStatus status;
-
-            if (rawMPDUCount == 1) {
-              // offset the raw packet start by 1
-              status = myMac1->processUHFPacket(mpdusBuffer+rawMPDUCount*MPDU::rawMPDULength() + 1, MPDU::rawMPDULength());
-            } else {
-              status = myMac1->processUHFPacket(mpdusBuffer+rawMPDUCount*MPDU::rawMPDULength(), MPDU::rawMPDULength());
+              recvPacketGood = !same;
+              ASSERT_FALSE(same) << "Scenario 2; decoded packet matches original even though an MPDU was dropped";
             }
-
-            switch (status) {
-              case MAC::MAC_UHFPacketProcessingStatus::PACKET_READY:
-              {
-                const uint8_t *rawPacket = myMac1->getRawPacketBuffer();
-
-                bool same = true;
-                for (uint16_t i = 0; i < myMac1->getRawPacketLength(); i++) {
-                  same = same && (rawPacket[i] == packet[i]);
-                }
-                ASSERT_FALSE(same) << "decoded packet matches original even though an MPDU was mangled";
-              }
+            break;
+            case MAC::MAC_UHFPacketProcessingStatus::READY_FOR_NEXT_UHF_PACKET:
               break;
-              case MAC::MAC_UHFPacketProcessingStatus::READY_FOR_NEXT_UHF_PACKET:
-                break;
-              default:
-                break;
-            } // switch on returned UHF packet process status
+            default:
+              break;
+          } // switch on returned UHF packet process status
+        } // skip the second MPDU
+      } // for all the raw MPDUs except the second
+      ASSERT_TRUE(recvPacketGood) << "Scenario 2; A packet should have been received even though second raw MPDU was missing.";
 
-          } // for all the raw MPDUs except the first
+      //////////////////////////////////////////////////////////////////////////
+      // Scenario 3; Receive the first two raw MPDUs, fragment indices 0 and 1,
+      // then receive "new" packet (an MPDU with fragment index 0).
+      // Expected result; Only one packet is produced; it will not be correct, but that
+      // is to be dealt with by an upper layer. Check the packet does not match
+      // the original.
+      //////////////////////////////////////////////////////////////////////////
+#if QA_MAC_VERBOSE_DEBUG
+      printf("Scenario 3; incomplete packet when new packet arrives.\n");
+#endif
+      recvPacketGood = false;
+      for (uint16_t rawMPDUCount = 0; rawMPDUCount < 2; rawMPDUCount++) {
+        MAC::MAC_UHFPacketProcessingStatus status = myMac1->processUHFPacket(mpdusBuffer+rawMPDUCount*MPDU::rawMPDULength(), MPDU::rawMPDULength());
 
-        } // check if have an integral number of raw MPDUs
-      } // was the packet successfully encoded
+        switch (status) {
+          case MAC::MAC_UHFPacketProcessingStatus::PACKET_READY:
+          {
+            // It's bad mojo to end up here since we did not provide all the MPDUs.
+            recvPacketGood = true;
+          }
+          break;
+          case MAC::MAC_UHFPacketProcessingStatus::READY_FOR_NEXT_UHF_PACKET:
+            break;
+          default:
+            break;
+        } // switch on returned UHF packet process status
+
+      } // for only the first two raw MPDUs
+      ASSERT_FALSE(recvPacketGood) << "Scenario 3; A packet should not been received at this point as only two raw MPDUs have been processed.";
+#if QA_MAC_VERBOSE_DEBUG
+      printf("first two PMDUs received... now send a new MPDU 0\n");
+#endif
+      // Now receive another packet.
+      recvPacketGood = false;
+      for (uint16_t rawMPDUCount = 0; rawMPDUCount < numMPDUs; rawMPDUCount++) {
+        MAC::MAC_UHFPacketProcessingStatus status = myMac1->processUHFPacket(mpdusBuffer+rawMPDUCount*MPDU::rawMPDULength(), MPDU::rawMPDULength());
+        switch (status) {
+          case MAC::MAC_UHFPacketProcessingStatus::PACKET_READY:
+          {
+            const uint8_t *rawPacket = myMac1->getRawPacketBuffer();
+
+#if QA_MAC_DEBUG
+            printf("original packet length %ld raw packet length %d \n",
+              packetDataLengths[currentPacket], myMac1->getRawPacketBufferLength());
+            for (uint16_t i = 0; i < myMac1->getRawPacketLength(); i++) {
+              printf("%04d %02x|%02x\n",i,rawPacket[i],packet[i]);
+            }
+            printf("------------\n");
+#endif
+            bool same = true;
+            for (uint16_t i = 0; same && (i < myMac1->getRawPacketLength()); i++) {
+              same = same && (rawPacket[i] == packet[i]);
+            }
+            recvPacketGood = same;
+#if QA_MAC_VERBOSE_DEBUG
+            printf("Scenario 3 packet rec'd\n");
+#endif
+            ASSERT_TRUE(same) << "Scenario 3; the decoded packet does not match original even though all raw MPDUs received";
+          }
+          break;
+          case MAC::MAC_UHFPacketProcessingStatus::READY_FOR_NEXT_UHF_PACKET:
+            break;
+          default:
+            break;
+        } // switch on returned UHF packet process status
+
+      } // for all raw MPDUs
+      ASSERT_TRUE(recvPacketGood) << "Scenario 3; A packet should have been received.";
+
+      //////////////////////////////////////////////////////////////////////////
+      // Scenario 4; Receive raw MPDUs out of order after the first.
+      // Expected result; Only one packet is produced; it will not be correct, but that
+      // is to be dealt with by an upper layer. Check the packet does not match
+      // the original.
+      //////////////////////////////////////////////////////////////////////////
+#if QA_MAC_VERBOSE_DEBUG
+      printf("Scenario 4; Raw MPDUs arrive out of order.\n");
+#endif
+      // Get the first raw MPDU and process.
+      uint16_t rawMPDUCount = 0;
+      MAC::MAC_UHFPacketProcessingStatus status = myMac1->processUHFPacket(mpdusBuffer+rawMPDUCount*MPDU::rawMPDULength(), MPDU::rawMPDULength());
+      switch (status) {
+        case MAC::MAC_UHFPacketProcessingStatus::PACKET_READY:
+        {
+          FAIL() << "Scenario 4; first MPDU should not result in packet";
+        }
+        break;
+        case MAC::MAC_UHFPacketProcessingStatus::READY_FOR_NEXT_UHF_PACKET:
+          break;
+        default:
+          break;
+      } // switch on returned UHF packet process status
+
+      // Get the third raw MPDU and process
+      rawMPDUCount = 2;
+      status = myMac1->processUHFPacket(mpdusBuffer+rawMPDUCount*MPDU::rawMPDULength(), MPDU::rawMPDULength());
+      switch (status) {
+        case MAC::MAC_UHFPacketProcessingStatus::PACKET_READY:
+        {
+          FAIL() << "Scenario 4; third MPDU should not result in packet";
+        }
+        break;
+        case MAC::MAC_UHFPacketProcessingStatus::READY_FOR_NEXT_UHF_PACKET:
+          break;
+        default:
+          break;
+      } // switch on returned UHF packet process status
+
+      // Get the second raw MPDU and process. Should put the state machine back
+      // looking for the first MPDU, but we can't tell that at this level.
+      rawMPDUCount = 1;
+      status = myMac1->processUHFPacket(mpdusBuffer+rawMPDUCount*MPDU::rawMPDULength(), MPDU::rawMPDULength());
+      switch (status) {
+        case MAC::MAC_UHFPacketProcessingStatus::PACKET_READY:
+        {
+          const uint8_t *rawPacket = myMac1->getRawPacketBuffer();
+
+          bool same = true;
+          for (uint16_t i = 0; i < myMac1->getRawPacketLength(); i++) {
+            same = same && (rawPacket[i] == packet[i]);
+          }
+          recvPacketGood = same;
+          ASSERT_FALSE(same) << "Scenario 4; decoded packet matches original even though MPDUs were out of order";
+        }
+        break;
+        case MAC::MAC_UHFPacketProcessingStatus::READY_FOR_NEXT_UHF_PACKET:
+        {
+          FAIL() << "Scenario 4; second (out of order) MPDU should result in packet";
+        }
+          break;
+        default:
+          break;
+      } // switch on returned UHF packet process status
+
+      // Finally, get the last raw MPDU and process. Since we expect the state
+      // machine to have been put back to looking for the first MPDU, providing
+      // the final MPDU should not result in a packet.
+      rawMPDUCount = numMPDUs - 1;
+      status = myMac1->processUHFPacket(mpdusBuffer+rawMPDUCount*MPDU::rawMPDULength(), MPDU::rawMPDULength());
+      switch (status) {
+        case MAC::MAC_UHFPacketProcessingStatus::PACKET_READY:
+        {
+          FAIL() << "Scenario 4; final MPDU should not result in packet";
+        }
+        break;
+        case MAC::MAC_UHFPacketProcessingStatus::READY_FOR_NEXT_UHF_PACKET:
+          break;
+        default:
+          break;
+      } // switch on returned UHF packet process status
+      ASSERT_FALSE(recvPacketGood) << "Scenario 4; A corrupted packet should have been received.";
+
+      //////////////////////////////////////////////////////////////////////////
+      // Scenario 5a); Receive raw MPDUs in order, but corrupt the MPDU header
+      // first Golay-encoded message (12 bits).
+      // Expected result; No packet is produced because the first MPDU is
+      // corrupted and the rest of the MPDUs are dropped.
+      //////////////////////////////////////////////////////////////////////////
+//#if QA_MAC_VERBOSE_DEBUG
+//      printf("Scenario 5a; Error correction scheme in MPDU header bits is corrupted.\n");
+//#endif
+//      recvPacketGood = false;
+//      for (uint16_t rawMPDUCount = 0; rawMPDUCount < numMPDUs; rawMPDUCount++) {
+//
+//        // Make a copy fo the current MPDU because we might use the original in a later test
+//        std::vector<uint8_t> rawMPDU;
+//        for (uint16_t i = 0; i < MPDU::rawMPDULength(); i++) {
+//          rawMPDU.push_back(mpdusBuffer[rawMPDUCount*MPDU::rawMPDULength()+i]);
+//        }
+//
+//        // Now, let's mangle the 5 MSBs of the 6-bit MPDUHeader error correction
+//        // enum, but only for the first MPDU
+//        if (rawMPDUCount == 0) {
+//#if QA_MAC_VERBOSE_DEBUG
+//          printf("Scenario 5a) rawMPDU[0] = 0x%02x ",rawMPDU[0]);
+//#endif
+//          uint8_t temp = ~rawMPDU[0];
+//          temp = (temp & 0x1F) | (rawMPDU[0] & 0xE0);
+//          rawMPDU[0] = temp;
+//#if QA_MAC_VERBOSE_DEBUG
+//          printf("temp = 0x%02x\n",temp);
+//#endif
+//        }
+//        try {
+//        // process the copy
+//        MAC::MAC_UHFPacketProcessingStatus status = myMac1->processUHFPacket(&rawMPDU[0], MPDU::rawMPDULength());
+//
+//        switch (status) {
+//          case MAC::MAC_UHFPacketProcessingStatus::PACKET_READY:
+//          {
+//            recvPacketGood = true;
+//            ASSERT_FALSE(recvPacketGood) << "Scenario 5a; A packet was decoded, which should not happen";
+//          }
+//          break;
+//          case MAC::MAC_UHFPacketProcessingStatus::READY_FOR_NEXT_UHF_PACKET:
+//            break;
+//          default:
+//            break;
+//        } // switch on returned UHF packet process status
+//        }
+//        catch (const MPDUException& e) {
+//
+//        }
+//
+//      } // for all raw MPDUs
+//      ASSERT_FALSE(recvPacketGood) << "Scenario 5a; A packet should not been received at this point";
+//
+//      //////////////////////////////////////////////////////////////////////////
+//      // Scenario 5b); Receive raw MPDUs in order, but corrupt the MPDU header
+//      // second Golay-encoded message (12 bits).
+//      // Expected result; One packet is produced; the user packet length field
+//      // is corrupted in the third MPDU, so the rest of the packet is padded
+//      // and then decoded.
+//      //////////////////////////////////////////////////////////////////////////
+//#if QA_MAC_VERBOSE_DEBUG
+//      printf("Scenario 5b; Uaser packet length in MPDU header bits is corrupted.\n");
+//#endif
+//      recvPacketGood = false;
+//      for (uint16_t rawMPDUCount = 0; rawMPDUCount < numMPDUs; rawMPDUCount++) {
+//
+//        // Make a copy fo the current MPDU because we might use the original in a later test
+//        std::vector<uint8_t> rawMPDU;
+//        for (uint16_t i = 0; i < MPDU::rawMPDULength(); i++) {
+//          rawMPDU.push_back(mpdusBuffer[rawMPDUCount*MPDU::rawMPDULength()+i]);
+//        }
+//
+//        // Now, let's mangle the 7 LSBs of the user packet length field in the
+//        // 3rd MPDU. Since the Golay-encoded codeword is 24 bits == 3 bytes, we
+//        // need to mangle the 7 LSBs of the 5th byte in the MPDU
+//        if (rawMPDUCount == 2) {
+//#if QA_MAC_VERBOSE_DEBUG
+//          printf("Scenario 5b) rawMPDU[4] = 0x%02x ",rawMPDU[4]);
+//#endif
+//          uint8_t temp = ~rawMPDU[4];
+//          temp = (temp & 0x7F) | (rawMPDU[4] & 0x80);
+//          rawMPDU[4] = temp;
+//#if QA_MAC_VERBOSE_DEBUG
+//          printf("temp = 0x%02x\n",rawMPDU[4]);
+//#endif
+//        }
+//        try {
+//        // process the copy
+//        MAC::MAC_UHFPacketProcessingStatus status = myMac1->processUHFPacket(&rawMPDU[0], MPDU::rawMPDULength());
+//
+//        switch (status) {
+//          case MAC::MAC_UHFPacketProcessingStatus::PACKET_READY:
+//          {
+//            const uint8_t *rawPacket = myMac1->getRawPacketBuffer();
+//
+//            bool same = true;
+//            for (uint16_t i = 0; i < myMac1->getRawPacketLength(); i++) {
+//              same = same && (rawPacket[i] == packet[i]);
+//            }
+//            recvPacketGood = same;
+//            ASSERT_FALSE(recvPacketGood) << "Scenario 5b; A packet was decoded with no errors, which should not happen";
+//          }
+//          break;
+//          case MAC::MAC_UHFPacketProcessingStatus::READY_FOR_NEXT_UHF_PACKET:
+//            break;
+//          default:
+//            break;
+//        } // switch on returned UHF packet process status
+//        }
+//        catch (const MPDUException& e) {
+//
+//        }
+//
+//      } // for all raw MPDUs
+//      ASSERT_FALSE(recvPacketGood) << "Scenario 5b; A good packet should not been received at this point";
+
+      //////////////////////////////////////////////////////////////////////////
+      // Scenario 5c); Receive raw MPDUs in order, but corrupt the MPDU header
+      // third Golay-encoded message (12 bits).
+      // Expected result; One packet is produced; the user packet fragment index
+      // is corrupted in the third MPDU, so the rest of the packet is padded
+      // and then decoded.
+      //////////////////////////////////////////////////////////////////////////
+#if QA_MAC_VERBOSE_DEBUG
+      printf("Scenario 5c; User packet fragment index in MPDU header bits is corrupted.\n");
+#endif
+      recvPacketGood = false;
+      for (uint16_t rawMPDUCount = 0; rawMPDUCount < numMPDUs; rawMPDUCount++) {
+
+        // Make a copy fo the current MPDU because we might use the original in a later test
+        std::vector<uint8_t> rawMPDU;
+        for (uint16_t i = 0; i < MPDU::rawMPDULength(); i++) {
+          rawMPDU.push_back(mpdusBuffer[rawMPDUCount*MPDU::rawMPDULength()+i]);
+        }
+
+        // Now, let's corrupt 7 bits of the user packet fragment index in the
+        // 3rd MPDU. Since the Golay-encoded codeword is 24 bits == 3 bytes, we
+        // need to mangle the LSB of the 9th byte in the MPDU
+        if (rawMPDUCount == 2) {
+#if QA_MAC_VERBOSE_DEBUG
+          for (uint16_t j=0; j < 9; j++) {
+            printf("0x%02X ",rawMPDU[j]);
+          }
+          printf("\n");
+          printf("Scenario 5c) rawMPDU[8] = 0x%02x ",rawMPDU[8]);
+#endif
+          uint8_t temp = (~rawMPDU[8]) & 0xFE;
+          rawMPDU[8] = rawMPDU[8] | temp;
+#if QA_MAC_VERBOSE_DEBUG
+          printf("temp = 0x%02x\n",rawMPDU[8]);
+#endif
+        }
+        try {
+          // process the copy
+          MAC::MAC_UHFPacketProcessingStatus status = myMac1->processUHFPacket(&rawMPDU[0], MPDU::rawMPDULength());
+
+          switch (status) {
+            case MAC::MAC_UHFPacketProcessingStatus::PACKET_READY:
+            {
+              const uint8_t *rawPacket = myMac1->getRawPacketBuffer();
+
+              bool same = true;
+              for (uint16_t i = 0; i < myMac1->getRawPacketLength(); i++) {
+                same = same && (rawPacket[i] == packet[i]);
+              }
+              recvPacketGood = same;
+              ASSERT_FALSE(recvPacketGood) << "Scenario 5c; A packet was decoded with no errors, which should not happen";
+            }
+            break;
+            case MAC::MAC_UHFPacketProcessingStatus::READY_FOR_NEXT_UHF_PACKET:
+              break;
+            default:
+              break;
+          } // switch on returned UHF packet process status
+        }
+        catch (const MPDUException& e) {
+
+        }
+
+      } // for all raw MPDUs
+      ASSERT_FALSE(recvPacketGood) << "Scenario 5c; A good packet should not been received at this point";
 
       // Clean up!
       free(packet);
@@ -568,7 +811,7 @@ TEST(mac, PacketLoopbackDroppedPackets) {
 
   } // for a number of Error Correction schemes
 
-    delete myMac1;
+  delete myMac1;
 
 } // PacketLoopbackDroppedPackets
 

--- a/unit_tests/qa_mpdu.cpp
+++ b/unit_tests/qa_mpdu.cpp
@@ -117,7 +117,7 @@ TEST(mpdu, ConstructorsAndAccessors)
 #endif
 
   // Instantiate a second object using the raw data constructor
-  MPDU *mpdu2 = new MPDU(rawMPDU);
+  MPDU *mpdu2 = new MPDU(errorCorrection, rawMPDU);
 
   ASSERT_TRUE(mpdu2 != NULL) << "MPDU 2 failed to instantiate";
 

--- a/unit_tests/qa_mpduHeader.cpp
+++ b/unit_tests/qa_mpduHeader.cpp
@@ -32,15 +32,15 @@ using namespace ex2::sdr;
 
 #include "gtest/gtest.h"
 
-#define QA_MPDUHEADER_DEBUG 0 // set to 1 for debugging output
+#define QA_MPDUHEADER_DEBUG 0         // set to 1 for debugging output
+#define QA_MPDUHEADER_DEBUG_VERBOSE 0 // set to 1 for verbose debugging output
 
 bool headersSame(MPDUHeader *h1, MPDUHeader *h2) {
   bool same = true;
 
-#if QA_MPDUHEADER_DEBUG
-  /*printf(" 0x%04x 0x%04x\n",h1->getUhfPacketLength(), h2->getUhfPacketLength());*/
-  printf(" 0x%04x 0x%04x\n",h1->getRfModeNumber(), h2->getRfModeNumber());
-  printf(" 0x%04x 0x%04x\n",h1->getErrorCorrectionScheme(), h2->getErrorCorrectionScheme());
+#if QA_MPDUHEADER_DEBUG_VERBOSE
+  printf(" 0x%04x 0x%04x\n",(unsigned int) h1->getRfModeNumber(), (unsigned int) h2->getRfModeNumber());
+  printf(" 0x%04x 0x%04x\n",(unsigned int) h1->getErrorCorrectionScheme(), (unsigned int) h2->getErrorCorrectionScheme());
   printf(" 0x%04x 0x%04x\n",h1->getCodewordFragmentIndex(), h2->getCodewordFragmentIndex());
   printf(" 0x%04x 0x%04x\n",h1->getUserPacketPayloadLength(), h2->getUserPacketPayloadLength());
   printf(" 0x%04x 0x%04x\n",h1->getUserPacketFragmentIndex(), h2->getUserPacketFragmentIndex());
@@ -107,7 +107,7 @@ TEST(mpduHeader, ConstructorParemeterized )
               std::vector<uint8_t> payload1 = header1->getHeaderPayload();
 
               try {
-                header2 = new MPDUHeader(payload1);
+                header2 = new MPDUHeader(errorCorrection, payload1);
               }
               catch (MPDUHeaderException &e) {
                 FAIL() << e.what();
@@ -178,32 +178,190 @@ TEST(mpduHeader, Accessors )
   uint16_t headerLength = header1->MACHeaderLength();
   ASSERT_TRUE(headerLength == MPDUHeader::MACHeaderLength()) << "Header length is wrong!";
 
-
+  // Get the raw header payload
   std::vector<uint8_t> payload1 = header1->getHeaderPayload();
 
-  // Make the payload long enough
+  // Turned it into a full packet payload since that is what we expect will be
+  // passed to the raw header constructor
   payload1.resize(UHF_TRANSPARENT_MODE_DATA_FIELD_2_MAX_LENGTH + 1);
-  header2 = new MPDUHeader(payload1);
+  try {
+    header2 = new MPDUHeader(ec, payload1);
 
-  modulationAccess = header2->getRfModeNumber();
-  ASSERT_TRUE(modulationAccess == modulation) << "modulation aka RF_Mode doesn't match!";
+    modulationAccess = header2->getRfModeNumber();
+    ASSERT_TRUE(modulationAccess == modulation) << "modulation aka RF_Mode doesn't match!";
 
-  ecScheme = header2->getErrorCorrectionScheme();
-  ASSERT_TRUE(errorCorrectionScheme == ecScheme) << "ErrorCorrectionScheme doesn't match!";
+    ecScheme = header2->getErrorCorrectionScheme();
+    ASSERT_TRUE(errorCorrectionScheme == ecScheme) << "ErrorCorrectionScheme doesn't match!";
 
-  cwFragmentIndex = header2->getCodewordFragmentIndex();
-  ASSERT_TRUE(codewordFragmentIndex == cwFragmentIndex) << "codeword fragment indices don't match!";
+    cwFragmentIndex = header2->getCodewordFragmentIndex();
+    ASSERT_TRUE(codewordFragmentIndex == cwFragmentIndex) << "codeword fragment indices don't match!";
 
-  uPacketLen = header2->getUserPacketPayloadLength();
-  ASSERT_TRUE(userPacketPayloadLength == uPacketLen) << "User packet lenghts don't match!";
+    uPacketLen = header2->getUserPacketPayloadLength();
+    ASSERT_TRUE(userPacketPayloadLength == uPacketLen) << "User packet lenghts don't match!";
 
-  uPacketFragIndex = header2->getUserPacketFragmentIndex();
-  ASSERT_TRUE(userPacketFragmentIndex == uPacketFragIndex) << "user packet fragment indices don't match!";
+    uPacketFragIndex = header2->getUserPacketFragmentIndex();
+    ASSERT_TRUE(userPacketFragmentIndex == uPacketFragIndex) << "user packet fragment indices don't match!";
 
-  headerLength = header2->MACHeaderLength();
-  ASSERT_TRUE(headerLength == MPDUHeader::MACHeaderLength()) << "Header length is wrong!";
+    headerLength = header2->MACHeaderLength();
+    ASSERT_TRUE(headerLength == MPDUHeader::MACHeaderLength()) << "Header length is wrong!";
 
-  delete(header2);
+  }
+  catch(MPDUHeaderException &e) {
+
+  };
+  if (!header2)
+    delete(header2);
   delete(header1);
 }
 
+/*!
+ * @brief Test raw header reconstruction including with bad data (bit errors
+ * were introduced)
+ */
+TEST(mpduHeader, RawReconstruction )
+{
+  /* ---------------------------------------------------------------------
+   * Check all accessors for both constructors
+   * ---------------------------------------------------------------------
+   */
+
+// @todo do this for all supported FEC schemes, maybe in combination with RF modes?
+// @todo should really break into multiple unit tests...
+
+  RF_Mode::RF_ModeNumber modulation = RF_Mode::RF_ModeNumber::RF_MODE_3; // 0b011
+  ErrorCorrection::ErrorCorrectionScheme errorCorrectionScheme =
+      ErrorCorrection::ErrorCorrectionScheme::IEEE_802_11N_QCLDPC_648_R_1_2; // 0b000000
+  ErrorCorrection ec(errorCorrectionScheme, MPDU::maxMTU() * 8);
+  uint8_t codewordFragmentIndex = 0x55;
+  uint16_t userPacketPayloadLength = 1234; // 0x04d2
+  uint8_t userPacketFragmentIndex = 0xAA;
+
+  MPDUHeader *header1, *header2;
+
+  // header1 is the reference, good header.
+  header1 = new MPDUHeader(
+    modulation,
+    ec,
+    codewordFragmentIndex,
+    userPacketPayloadLength,
+    userPacketFragmentIndex);
+
+  // Being really redundant, check all the accessors for header1 return the
+  // right values.
+  RF_Mode::RF_ModeNumber modulationAccess = header1->getRfModeNumber();
+  ASSERT_TRUE(modulationAccess == modulation) << "modulation aka RF_Mode doesn't match!";
+
+  ErrorCorrection::ErrorCorrectionScheme ecScheme = header1->getErrorCorrectionScheme();
+  ASSERT_TRUE(errorCorrectionScheme == ecScheme) << "ErrorCorrectionScheme doesn't match!";
+
+  uint8_t cwFragmentIndex = header1->getCodewordFragmentIndex();
+  ASSERT_TRUE(codewordFragmentIndex == cwFragmentIndex) << "codeword fragment indices don't match!";
+
+  uint16_t uPacketLen = header1->getUserPacketPayloadLength();
+  ASSERT_TRUE(userPacketPayloadLength == uPacketLen) << "User packet lenghts don't match!";
+
+  uint8_t uPacketFragIndex = header1->getUserPacketFragmentIndex();
+  ASSERT_TRUE(userPacketFragmentIndex == uPacketFragIndex) << "user packet fragment indices don't match!";
+
+  uint16_t headerLength = header1->MACHeaderLength();
+  ASSERT_TRUE(headerLength == MPDUHeader::MACHeaderLength()) << "Header length is wrong!";
+
+  //
+  // First test, very bad header
+  //
+
+  // Get the raw header payload
+  std::vector<uint8_t> payload1 = header1->getHeaderPayload();
+
+  // Turned it into a full packet payload since that is what we expect will be
+  // passed to the raw header constructor
+  payload1.resize(UHF_TRANSPARENT_MODE_DATA_FIELD_2_MAX_LENGTH + 1);
+
+  // Now, let's mangle the whole raw header
+  for (unsigned int i = 0; i < MPDUHeader::MACHeaderLength(); i++) {
+    payload1[i] = payload1[i] ^ 0x55;
+  }
+
+  // @Note we could use the Google Test "EXPECT_THROW", but I don't seem able
+  // to embedded blocks properly, so we do it the old way.
+
+  // We expect problems...
+  try {
+    header2 = new MPDUHeader(ec, payload1);
+    EXPECT_TRUE(false) << "The corrupted raw header should have caused an exception";
+  }
+  catch(MPDUHeaderException &e) {
+#if QA_MPDUHEADER_DEBUG
+    printf("With the entire MPDUHeader mangled, exception is ... %s\n",e.what());
+#endif
+  };
+  if (!header2)
+    delete(header2);
+
+  //
+  // Second test, only the error correction scheme enum is twiddled, but not
+  // enough to prevent the packet from working
+  //
+
+  // Get the raw header payload
+  payload1 = header1->getHeaderPayload();
+
+  // Turned it into a full packet payload since that is what we expect will be
+  // passed to the raw header constructor
+  payload1.resize(UHF_TRANSPARENT_MODE_DATA_FIELD_2_MAX_LENGTH + 1);
+
+  // Now, let's mangle the 1 bit of the MPDUHeader error correction enum. The
+  // MSB of that value is bit 4 of the first payload byte.
+  uint8_t temp = payload1[0] ^ 0x01; // flip bit 2 of the 6-bit error correction scheme
+#if QA_MPDUHEADER_DEBUG
+  printf("payload1[0] 0x%02X temp 0x%02X\n",payload1[0],temp);
+#endif
+  payload1[0] = temp;
+
+  // We expect no problems...
+  try {
+    header2 = new MPDUHeader(ec, payload1);
+  }
+  catch(MPDUHeaderException &e) {
+    EXPECT_TRUE(false) << "The corrupted raw header should not have caused an exception";
+#if QA_MPDUHEADER_DEBUG
+    printf("With the 1 bit of MPDUHeader mangled, exception is ... %s\n",e.what());
+#endif
+  };
+  if (!header2)
+    delete(header2);
+
+  //
+  // third test, 5 of 6 bits in the error correction scheme enum are flipped
+  //
+
+  // Get the raw header payload
+  payload1 = header1->getHeaderPayload();
+
+  // Turned it into a full packet payload since that is what we expect will be
+  // passed to the raw header constructor
+  payload1.resize(UHF_TRANSPARENT_MODE_DATA_FIELD_2_MAX_LENGTH + 1);
+
+  // Now, let's mangle the 5 MSBs of the 6-bit MPDUHeader error correction enum.
+  temp = ~payload1[0];
+  temp = (temp & 0x1F) | (payload1[0] & 0xE0);
+#if QA_MPDUHEADER_DEBUG
+  printf("payload1[0] 0x%02X temp  0x%02X\n",payload1[0], temp);
+#endif
+  payload1[0] = temp;
+
+  // We expect problems...
+  try {
+    header2 = new MPDUHeader(ec, payload1);
+    EXPECT_TRUE(false) << "The corrupted raw header should not have caused an exception";
+  }
+  catch(MPDUHeaderException &e) {
+#if QA_MPDUHEADER_DEBUG
+    printf("With the 5 of 6 error correction enum bits mangled, exception is ... %s\n",e.what());
+#endif
+  };
+  if (!header2)
+    delete(header2);
+
+  delete(header1);
+}


### PR DESCRIPTION
Except for a timer to manage the case where the final raw MPDU is not received and a user packet cannot be completed (even with zero-padding), as many corner cases as I can imagine have been baked into the MAC code. Some changes to MPDU and MPDU Header and clean up of golay.* was needed. Specifically, since the error correction scheme is set when the MAC is instantiated, we should be able to check in the header if the error correction scheme is legit.

Unit tests are all updated and/or extended, but IMHO too much is being done per unit test and I should refactor to make each do one thing only... work for another day? 