### PR TITLE
Increase rx timeout for linux

### DIFF
--- a/lib/driver/sdr_driver.c
+++ b/lib/driver/sdr_driver.c
@@ -2,6 +2,7 @@
 #include "sdr_driver.h"
 #include "fec.h"
 #include "osal.h"
+#include <stdio.h>
 
 #define PIPE_ENTER_MSG_LEN 15
 #define PIPE_EXIT_MSG_LEN 16
@@ -37,7 +38,7 @@ void sdr_rx_isr(void *cb_data, uint8_t *buf, size_t len, void *pxTaskWoken) {
     sdr_interface_data_t *ifdata = (sdr_interface_data_t *)cb_data;
 
     uint8_t *ptr = buf;
-    if (os_get_ms() - ifdata->last_rx > 10) {
+    if (os_get_ms() - ifdata->last_rx > 100) {
         ifdata->rx_mpdu_index = 0;
     }
     ifdata->last_rx = os_get_ms();


### PR DESCRIPTION
On the satellite, this isr receives one byte at a time until 128 are received
On linux, the read() function that gets the data to pass here reads anywhere between
1 and 128 bytes. If a partial read was done, as in length < 128, by the time this
function was called a second time, more than 10ms had passed and the code would drop the
first portion of the mpdu. Just an assumption about non real time operating systems I missed