### PR TITLE
added ground station uhf baud rate symbol and delay

### DIFF
--- a/include/driver/sdr_driver.h
+++ b/include/driver/sdr_driver.h
@@ -17,7 +17,7 @@ typedef enum {
     SDR_UHF_9600_BAUD,
     SDR_UHF_19200_BAUD,
     SDR_UHF_TEST_BAUD,
-    SDR_UHF_GND_STATION_BAUD,
+    SDR_UHF_GNURADIO_BAUD,
     SDR_UHF_END_BAUD,
 } sdr_uhf_baud_rate_t;
 

--- a/include/driver/sdr_driver.h
+++ b/include/driver/sdr_driver.h
@@ -17,6 +17,7 @@ typedef enum {
     SDR_UHF_9600_BAUD,
     SDR_UHF_19200_BAUD,
     SDR_UHF_TEST_BAUD,
+    SDR_UHF_GND_STATION_BAUD,
     SDR_UHF_END_BAUD,
 } sdr_uhf_baud_rate_t;
 

--- a/lib/driver/sdr_driver.c
+++ b/lib/driver/sdr_driver.c
@@ -15,7 +15,7 @@ static int sdr_uhf_baud_rate_delay[] = {
     [SDR_UHF_9600_BAUD] = 120,
     [SDR_UHF_19200_BAUD] = 60,
     [SDR_UHF_TEST_BAUD] = 20,
-    [SDR_UHF_GND_STATION_BAUD] = 0
+    [SDR_UHF_GNURADIO_BAUD] = 0
 };
 
 int sdr_uhf_tx(sdr_interface_data_t *ifdata, uint8_t *data, uint16_t len) {

--- a/lib/driver/sdr_driver.c
+++ b/lib/driver/sdr_driver.c
@@ -14,7 +14,8 @@ static int sdr_uhf_baud_rate_delay[] = {
     [SDR_UHF_4800_BAUD] = 240,
     [SDR_UHF_9600_BAUD] = 120,
     [SDR_UHF_19200_BAUD] = 60,
-    [SDR_UHF_TEST_BAUD] = 20
+    [SDR_UHF_TEST_BAUD] = 20,
+    [SDR_UHF_GND_STATION_BAUD] = 0
 };
 
 int sdr_uhf_tx(sdr_interface_data_t *ifdata, uint8_t *data, uint16_t len) {


### PR DESCRIPTION
GS transmit doesn't need delays between packets, so this speeds up file upload significantly.

Must be merged alongside respectively named PRs in libcsp and ex2_ground_station_software.