### PR TITLE
Add debug guard around printf

### DIFF
--- a/lib/mac_layer/pdu/mpdu.cpp
+++ b/lib/mac_layer/pdu/mpdu.cpp
@@ -42,7 +42,9 @@ namespace ex2
       }
       catch (MPDUHeaderException& e) {
         // @todo should log this
+#if MPDU_DEBUG
         printf("MPDUHeader exception : %s\n", e.what());
+#endif
         throw MPDUException("MPDU: Bad MPDUHeader.");
       }
     }
@@ -94,9 +96,9 @@ namespace ex2
       }
       catch (MPDUHeaderException& e) {
         // @todo should log this
-//#if MPDU_DEBUG
+#if MPDU_DEBUG
         printf("MPDUHeader exception : %s\n", e.what());
-//#endif
+#endif
         throw MPDUException("MPDU: Bad raw MPDUHeader.");
       }
 


### PR DESCRIPTION
TI's mean silicon was having an AXI slave abort when this printf was in place and optimization was set to -O3