### PR TITLE
turn FEC on/off at runtime

### DIFF
--- a/include/driver/sdr_driver.h
+++ b/include/driver/sdr_driver.h
@@ -98,6 +98,8 @@ os_task_return_t sdr_rx_task(void *param);
 
 int sdr_uhf_set_rf_mode(sdr_interface_data_t *sdr_ifdata, uint8_t rf_mode);
 
+bool sdr_fec_ctl(sdr_interface_data_t *sdr_ifdata, bool use_fec);
+
 #ifdef __cplusplus
 }
 #endif

--- a/include/mac_layer/pdu/mpduHeader.hpp
+++ b/include/mac_layer/pdu/mpduHeader.hpp
@@ -59,14 +59,11 @@ namespace ex2 {
        * @details Reconstitute a header object from raw (received, we assume)
        * bytes. Check the data for correctness and throw an exepction if bad.
        *
-       * @param[in] currentErrorCorrection The current ErrorCorrection scheme in
-       * use by the MAC.
        * @param[in] rawHeader The first @p k_MACHeaderLength / 8 bytes of this
        * vector are assumed to contain the MACHeader information.
        * @throws MPDUHeaderException
        */
-      MPDUHeader (const ErrorCorrection &currentErrorCorrection,
-        std::vector<uint8_t> &rawHeader);
+      MPDUHeader (std::vector<uint8_t> &rawHeader);
 
       /*!
        * @brief Copy Constructor

--- a/lib/driver/sdr_init.c
+++ b/lib/driver/sdr_init.c
@@ -79,3 +79,14 @@ sdr_interface_data_t *sdr_interface_init(const sdr_conf_t *conf, const char *ifn
     return ifdata;
 }
 
+bool sdr_fec_ctl(sdr_interface_data_t *ifdata, bool use_fec) {
+    error_correction_scheme_t correction_scheme;
+
+    if (use_fec) {
+        correction_scheme = CCSDS_CONVOLUTIONAL_CODING_R_1_2;
+    } else {
+        correction_scheme = NO_FEC;
+    }
+
+    return set_error_correction_scheme(ifdata->mac_data, correction_scheme);
+}

--- a/lib/mac_layer/mac.cpp
+++ b/lib/mac_layer/mac.cpp
@@ -400,8 +400,7 @@ namespace ex2 {
 #if MAC_DEBUG
       uint32_t const cwLen = m_errorCorrection->getCodewordLen() / 8;
       printf("current ECS = %d\n", (uint16_t) getErrorCorrectionScheme());
-      uint32_t numMPDUsPerPacket = mpdusPerPacket(packet, *m_errorCorrection);
-      printf("numMPDUsPerPacket %d packetLength %d messageLength %d cwLen %d\n",numMPDUsPerPacket,packetLength,messageLength,cwLen);
+      printf("packetLength %d messageLength %d cwLen %d\n",packetLength,messageLength,cwLen);
 #endif
 
       // A packet is broken into codewords for transmission. Each codeword
@@ -535,7 +534,7 @@ namespace ex2 {
 #if MAC_DEBUG
       printf("Total MPDU bytes = %ld\n", m_transparentModePayloads.size());
       for (unsigned int i = 0; i < m_transparentModePayloads.size(); i++) {
-        printf("tpmodePayaloads[%04d] 0x%02x\n",i,m_transparentModePayloads[i]);
+        printf("tpmodePayloads[%04d] 0x%02x\n",i,m_transparentModePayloads[i]);
       }
 #endif
       return true; // @todo not yet sure when we'd return false. Only if FEC encoding fails, so check that possibility

--- a/lib/mac_layer/pdu/mpdu.cpp
+++ b/lib/mac_layer/pdu/mpdu.cpp
@@ -80,7 +80,7 @@ namespace ex2
       // >
 
       try {
-        m_mpduHeader = new MPDUHeader(currentErrorCorrection, rawMPDU);
+        m_mpduHeader = new MPDUHeader(rawMPDU);
 
         // Header seems okay, so make codeword based on how many remaining bytes
         // in rawMPDU

--- a/lib/mac_layer/pdu/mpduHeader.cpp
+++ b/lib/mac_layer/pdu/mpduHeader.cpp
@@ -47,8 +47,7 @@ namespace ex2 {
       m_headerValid = true;
     }
 
-    MPDUHeader::MPDUHeader (const ErrorCorrection &currentErrorCorrection,
-      std::vector<uint8_t> &rawHeader){
+    MPDUHeader::MPDUHeader(std::vector<uint8_t> &rawHeader) {
 
       if (rawHeader.size() < (k_MACHeaderLength / 8)) {
         throw MPDUHeaderException("MPDUHeader: Raw header too short");
@@ -61,14 +60,6 @@ namespace ex2 {
 
           // @TODO Any rfMode value is valid, and we really don't do anything with
           // rfMode yet, so not worth checking.
-
-          // It's possible that the check for a valid error correction scheme in
-          // decodeMACHeader passes, but it's still the wrong scheme, not the
-          // one in actual use.
-          if (m_errorCorrection->getErrorCorrectionScheme() != currentErrorCorrection.getErrorCorrectionScheme()){
-            // The header is bad
-            throw MPDUHeaderException("MPDUHeader: Bad transparent mode packet data; ErrorCorrectionScheme not allowed.");
-          }
         }
         else {
           throw MPDUHeaderException("MPDUHeader: Too many bit errors.");


### PR DESCRIPTION
Use the error-scheme bits in the MPDU header to specify how the data is protected. Note the header is always Golay encoded. Also add a call so that the system can turn FEC on or off, depending on the current SNR